### PR TITLE
refactor: slim the metadata transport to type and panel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,12 +111,12 @@ Figures store metadata for composition operations (Panel, Grid):
 
 ```python
 figure._chart_metadata = {
-    "charts": [...],        # the raw chart dicts
     "type": "linechart",    # or "overlay"
     "panel": Panel(...),    # Layer objects + panel settings; redraws into any axes
-    # ... other attributes
 }
 ```
+
+The transport carries only what composition consumes — never the raw attrs dicts.
 
 `Panel` concatenates the source figures' layer groups into one panel with
 twin-axis assignment; `Grid` renders each figure's stored panel into a grid

--- a/datachart/utils/_internal/plot_engine.py
+++ b/datachart/utils/_internal/plot_engine.py
@@ -356,10 +356,11 @@ def render_chart(attrs: ChartAttrs) -> plt.Figure:
         chart_type, settings, "composition", first_style
     )
     composition_settings["title"] = charts[0].get("subtitle", None)
-    metadata = dict(attrs)
-    metadata["panel"] = Panel(
-        [group_from_chart(layers, settings, mode="multiple")], composition_settings
-    )
-    figure._chart_metadata = metadata
+    figure._chart_metadata = {
+        "type": chart_type,
+        "panel": Panel(
+            [group_from_chart(layers, settings, mode="multiple")], composition_settings
+        ),
+    }
 
     return figure

--- a/datachart/utils/figure.py
+++ b/datachart/utils/figure.py
@@ -152,11 +152,6 @@ def _figure_grid_layout_impl(
             raise ValueError(
                 f"Figure at index {idx} is a Grid figure; grid figures cannot be nested"
             )
-        if metadata.get("charts") is None:
-            raise ValueError(
-                f"Figure at index {idx} has invalid metadata: missing 'charts'"
-            )
-
         panel = metadata.get("panel")
         if panel is None:
             raise ValueError(

--- a/datachart/utils/overlay.py
+++ b/datachart/utils/overlay.py
@@ -56,9 +56,6 @@ def _extract_groups(figure: plt.Figure, index: int) -> List[LayerGroup]:
         raise ValueError(
             f"Figure at index {index} is a Grid figure; grid figures cannot be overlaid"
         )
-    if metadata.get("charts") is None:
-        raise ValueError("Figure has invalid metadata: missing 'charts'")
-
     panel = metadata.get("panel")
     if panel is None:
         raise ValueError("Figure has invalid metadata: missing 'panel'")
@@ -121,7 +118,6 @@ def _overlay_impl(
 
     # collect the layer groups from every source figure, tagged with prefs
     groups = []
-    all_charts = []
     for i, chart_config in enumerate(charts):
         if "figure" not in chart_config:
             raise ValueError(f"Chart at index {i} is missing 'figure' key")
@@ -135,11 +131,6 @@ def _overlay_impl(
                     legend_label=chart_config.get("legend_label", None),
                 )
             )
-        metadata_charts = figure._chart_metadata.get("charts")
-        if isinstance(metadata_charts, dict):
-            all_charts.append(metadata_charts)
-        else:
-            all_charts.extend(list(metadata_charts))
 
     # panel-level settings are resolved against the config here, at build time
     panel_settings = {
@@ -188,10 +179,7 @@ def _overlay_impl(
 
     fig._chart_metadata = {
         "type": "overlay",
-        "charts": all_charts,
         "panel": panel,
-        "title": title,
-        "figsize": figsize,
     }
 
     return fig

--- a/test/test_overlay.py
+++ b/test/test_overlay.py
@@ -377,11 +377,10 @@ class TestOverlayChart:
         # Test required metadata fields
         metadata = overlay_fig._chart_metadata
         assert "type" in metadata, "Missing 'type' in metadata"
-        assert "charts" in metadata, "Missing 'charts' in metadata"
         assert (
             metadata["type"] == "overlay"
         ), f"Expected type 'overlay', got '{metadata['type']}'"
-        assert len(metadata["charts"]) > 0, "Charts list should not be empty"
+        assert "panel" in metadata, "Missing 'panel' in metadata"
 
         plt.close(overlay_fig)
         plt.close(bar_fig)


### PR DESCRIPTION
## Summary
Slims the chart-metadata transport to only what composition consumes: `figure._chart_metadata` now carries `{"type", "panel"}` (grid figures stay `{"type": "grid"}`). This closes out candidate C2 ("stop smuggling the chart spec through `figure._chart_metadata`") — the raw attrs dicts rode along as dead weight after ADR 0001/0002 made the `Panel` the sole drawing path, and CONTEXT.md's "Metadata transport" entry already described this end-state.

## Changes
- `plot_engine.py` no longer copies the full `dict(attrs)` onto the figure — the transport is built as `{"type": chart_type, "panel": Panel(...)}`.
- `overlay.py` drops the `all_charts` accumulation and the unread `title`/`figsize` keys from the overlay figure's metadata.
- The `missing 'charts'` validations in `overlay.py` and `figure.py` are removed (composition validates `type` and `panel` only).
- `test_overlay.py` metadata assertions updated (`panel` instead of `charts`); CLAUDE.md's Chart Metadata section reflects the slim transport.
- No back-compat shim: `_chart_metadata` is a private, undocumented attribute.

## Test plan
- `python -m unittest discover test` → 36 passed
- `pytest test/test_overlay.py test/test_compose.py` → 37 passed
- `python test/golden/golden.py candidate` → 43/43 byte-identical to a baseline generated at the branch point (no rendering change)
