### PR TITLE
refactor: retire the attrs dict; chart fronts pass explicit settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,9 +96,9 @@ from datachart.config import config
 ### Chart Creation Flow
 
 1. User calls a chart front (e.g., `LineChart(...)`) in `datachart/charts/line_chart.py`
-2. The front builds the attrs dict using `build_charts_structure()` and `build_attrs_dict()` from `chart_builder.py`
+2. The front builds the charts structure via `build_charts_structure()` from `chart_builder.py` and an explicit settings dict, then calls `render_chart(chart_type, charts, settings)` (ADR 0003)
 3. `render_chart()` in `plot_engine.py`:
-   - Extracts and validates settings, calculates the subplot layout
+   - Calculates the subplot layout; `None` settings resolve to defaults at point of use
    - Builds the layers via `build_layers()` — style is resolved here, once
    - Assembles one `Panel` per coordinate space (one for single plots, one per subplot otherwise) and calls `panel.render(ax)`
    - Applies figure-level labels and stores the metadata transport on the figure
@@ -116,7 +116,7 @@ figure._chart_metadata = {
 }
 ```
 
-The transport carries only what composition consumes — never the raw attrs dicts.
+The transport carries only what composition consumes — never the fronts' inputs.
 
 `Panel` concatenates the source figures' layer groups into one panel with
 twin-axis assignment; `Grid` renders each figure's stored panel into a grid

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -35,8 +35,9 @@ _Avoid_: settings (for this), kwargs
 
 **Chart front**:
 A public chart function (`LineChart`, `BarChart`, …) — a thin front that validates
-input and builds layers; it does not draw.
-_Avoid_: chart class, chart type (for the function)
+input and hands the engine an explicit charts structure and settings dict; it does
+not draw, and its signature is the allowlist of what the chart supports.
+_Avoid_: chart class, chart type (for the function), attrs dict
 
 **Metadata transport**:
 The chart spec riding on a rendered figure (`figure._chart_metadata`) so composition

--- a/datachart/charts/bar_chart.py
+++ b/datachart/charts/bar_chart.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     BarDataPointAttrs,
     BarStyleAttrs,
@@ -151,32 +151,30 @@ def BarChart(
         yerr=yerr,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "barchart",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        xmin=xmin,
-        xmax=xmax,
-        ymin=ymin,
-        ymax=ymax,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-        subplots=subplots,
-        max_cols=max_cols,
-        sharex=sharex,
-        sharey=sharey,
-        show_yerr=show_yerr,
-        show_values=show_values,
-        value_format=value_format,
-        orientation=orientation,
-        bar_mode=bar_mode,
-        scalex=scalex,
-        scaley=scaley,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "xmin": xmin,
+        "xmax": xmax,
+        "ymin": ymin,
+        "ymax": ymax,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+        "subplots": subplots,
+        "max_cols": max_cols,
+        "sharex": sharex,
+        "sharey": sharey,
+        "show_yerr": show_yerr,
+        "show_values": show_values,
+        "value_format": value_format,
+        "orientation": orientation,
+        "bar_mode": bar_mode,
+        "scalex": scalex,
+        "scaley": scaley,
+    }
 
-    return render_chart(attrs)
+    return render_chart("barchart", charts, settings)

--- a/datachart/charts/box_plot.py
+++ b/datachart/charts/box_plot.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     BoxDataPointAttrs,
     BoxStyleAttrs,
@@ -143,29 +143,27 @@ def BoxPlot(
         value=value,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "boxplot",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        xmin=xmin,
-        xmax=xmax,
-        ymin=ymin,
-        ymax=ymax,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-        subplots=subplots,
-        max_cols=max_cols,
-        sharex=sharex,
-        sharey=sharey,
-        show_outliers=show_outliers,
-        show_notch=show_notch,
-        orientation=orientation,
-        scaley=scaley,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "xmin": xmin,
+        "xmax": xmax,
+        "ymin": ymin,
+        "ymax": ymax,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+        "subplots": subplots,
+        "max_cols": max_cols,
+        "sharex": sharex,
+        "sharey": sharey,
+        "show_outliers": show_outliers,
+        "show_notch": show_notch,
+        "orientation": orientation,
+        "scaley": scaley,
+    }
 
-    return render_chart(attrs)
+    return render_chart("boxplot", charts, settings)

--- a/datachart/charts/heatmap.py
+++ b/datachart/charts/heatmap.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     HeatmapStyleAttrs,
     HeatmapColorbarAttrs,
@@ -130,27 +130,25 @@ def Heatmap(
         colorbar=colorbar,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "heatmap",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        xmin=xmin,
-        xmax=xmax,
-        ymin=ymin,
-        ymax=ymax,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-        subplots=subplots,
-        max_cols=max_cols,
-        sharex=sharex,
-        sharey=sharey,
-        show_colorbars=show_colorbars,
-        show_heatmap_values=show_heatmap_values,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "xmin": xmin,
+        "xmax": xmax,
+        "ymin": ymin,
+        "ymax": ymax,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+        "subplots": subplots,
+        "max_cols": max_cols,
+        "sharex": sharex,
+        "sharey": sharey,
+        "show_colorbars": show_colorbars,
+        "show_heatmap_values": show_heatmap_values,
+    }
 
-    return render_chart(attrs)
+    return render_chart("heatmap", charts, settings)

--- a/datachart/charts/histogram.py
+++ b/datachart/charts/histogram.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     HistDataPointAttrs,
     HistStyleAttrs,
@@ -142,31 +142,29 @@ def Histogram(
         x=x,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "histogram",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        xmin=xmin,
-        xmax=xmax,
-        ymin=ymin,
-        ymax=ymax,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-        subplots=subplots,
-        max_cols=max_cols,
-        sharex=sharex,
-        sharey=sharey,
-        show_density=show_density,
-        show_cumulative=show_cumulative,
-        orientation=orientation,
-        num_bins=num_bins,
-        scalex=scalex,
-        scaley=scaley,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "xmin": xmin,
+        "xmax": xmax,
+        "ymin": ymin,
+        "ymax": ymax,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+        "subplots": subplots,
+        "max_cols": max_cols,
+        "sharex": sharex,
+        "sharey": sharey,
+        "show_density": show_density,
+        "show_cumulative": show_cumulative,
+        "orientation": orientation,
+        "num_bins": num_bins,
+        "scalex": scalex,
+        "scaley": scaley,
+    }
 
-    return render_chart(attrs)
+    return render_chart("histogram", charts, settings)

--- a/datachart/charts/line_chart.py
+++ b/datachart/charts/line_chart.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     LineDataPointAttrs,
     LineStyleAttrs,
@@ -144,29 +144,27 @@ def LineChart(
         yerr=yerr,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "linechart",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        xmin=xmin,
-        xmax=xmax,
-        ymin=ymin,
-        ymax=ymax,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-        subplots=subplots,
-        max_cols=max_cols,
-        sharex=sharex,
-        sharey=sharey,
-        show_yerr=show_yerr,
-        show_area=show_area,
-        scalex=scalex,
-        scaley=scaley,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "xmin": xmin,
+        "xmax": xmax,
+        "ymin": ymin,
+        "ymax": ymax,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+        "subplots": subplots,
+        "max_cols": max_cols,
+        "sharex": sharex,
+        "sharey": sharey,
+        "show_yerr": show_yerr,
+        "show_area": show_area,
+        "scalex": scalex,
+        "scaley": scaley,
+    }
 
-    return render_chart(attrs)
+    return render_chart("linechart", charts, settings)

--- a/datachart/charts/parallel_coords.py
+++ b/datachart/charts/parallel_coords.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple, Dict
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     ParallelCoordsDataPointAttrs,
     ParallelCoordsStyleAttrs,
@@ -91,17 +91,15 @@ def ParallelCoords(
         category_orders=category_orders,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "parallelcoords",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+    }
 
-    return render_chart(attrs)
+    return render_chart("parallelcoords", charts, settings)

--- a/datachart/charts/scatter_chart.py
+++ b/datachart/charts/scatter_chart.py
@@ -3,7 +3,7 @@ from typing import Union, List, Optional, Tuple
 import matplotlib.pyplot as plt
 
 from ..utils._internal.plot_engine import render_chart
-from ..utils._internal.chart_builder import build_charts_structure, build_attrs_dict
+from ..utils._internal.chart_builder import build_charts_structure
 from ..typings import (
     ScatterDataPointAttrs,
     ScatterStyleAttrs,
@@ -188,32 +188,30 @@ def ScatterChart(
         hue=hue,
     )
 
-    # Build the attrs dict using shared utility
-    attrs = build_attrs_dict(
-        "scatterchart",
-        charts,
-        title=title,
-        xlabel=xlabel,
-        ylabel=ylabel,
-        figsize=figsize,
-        xmin=xmin,
-        xmax=xmax,
-        ymin=ymin,
-        ymax=ymax,
-        show_legend=show_legend,
-        show_grid=show_grid,
-        aspect_ratio=aspect_ratio,
-        subplots=subplots,
-        max_cols=max_cols,
-        sharex=sharex,
-        sharey=sharey,
-        show_regression=show_regression,
-        show_ci=show_ci,
-        ci_level=ci_level,
-        show_correlation=show_correlation,
-        scalex=scalex,
-        scaley=scaley,
-        size_range=size_range,
-    )
+    # Figure-level settings; None values resolve to defaults downstream
+    settings = {
+        "title": title,
+        "xlabel": xlabel,
+        "ylabel": ylabel,
+        "figsize": figsize,
+        "xmin": xmin,
+        "xmax": xmax,
+        "ymin": ymin,
+        "ymax": ymax,
+        "show_legend": show_legend,
+        "show_grid": show_grid,
+        "aspect_ratio": aspect_ratio,
+        "subplots": subplots,
+        "max_cols": max_cols,
+        "sharex": sharex,
+        "sharey": sharey,
+        "show_regression": show_regression,
+        "show_ci": show_ci,
+        "ci_level": ci_level,
+        "show_correlation": show_correlation,
+        "scalex": scalex,
+        "scaley": scaley,
+        "size_range": size_range,
+    }
 
-    return render_chart(attrs)
+    return render_chart("scatterchart", charts, settings)

--- a/datachart/typings.py
+++ b/datachart/typings.py
@@ -3,32 +3,22 @@
 The `typings` module contains the typings for all chart components. The module
 is intended to contain the typings for easier input value format checkup.
 
-Attributes:
-    ChartAttrs: The union of all chart attributes.
-
 Classes:
     ChartCommonAttrs: The chart attributes common to all chart types.
     VLinePlotAttrs: The vertical line plot attributes.
     HLinePlotAttrs: The horizontal line plot attributes.
-    LineChartAttrs: The line chart attributes.
     LineSingleChartAttrs: The single chart attributes for the line chart.
     LineDataPointAttrs: The data point attributes for the line chart.
-    BarChartAttrs: The bar chart attributes.
     BarSingleChartAttrs: The single chart attributes for the bar chart.
     BarDataPointAttrs: The data point attributes for the bar chart.
-    HistogramChartAttrs: The histogram chart attributes.
     HistogramSingleChartAttrs: The single chart attributes for the histogram chart.
     HistDataPointAttrs: The data point attributes for the histogram chart.
-    HeatmapChartAttrs: The heatmap chart attributes.
     HeatmapSingleChartAttrs: The single chart attributes for the heatmap chart.
     HeatmapColorbarAttrs: The heatmap colorbar attributes.
-    ScatterChartAttrs: The scatter chart attributes.
     ScatterSingleChartAttrs: The single chart attributes for the scatter chart.
     ScatterDataPointAttrs: The data point attributes for the scatter chart.
-    BoxChartAttrs: The box plot chart attributes.
     BoxSingleChartAttrs: The single chart attributes for the box plot.
     BoxDataPointAttrs: The data point attributes for the box plot.
-    ParallelCoordsChartAttrs: The parallel coordinates chart attributes.
     ParallelCoordsSingleChartAttrs: The single chart attributes for the parallel coordinates chart.
     ParallelCoordsDataPointAttrs: The data point attributes for the parallel coordinates chart.
 
@@ -52,6 +42,7 @@ Classes:
 
 """
 
+import warnings
 from typing import TypedDict, Union, Tuple, List, Optional, Dict
 
 import matplotlib.colors as colors
@@ -695,7 +686,7 @@ class LineSingleChartAttrs(TypedDict):
     yerr: Union[str, None]  # the name of the yerr attribute in data (default: "yerr")
 
 
-class LineChartAttrs(ChartCommonAttrs):
+class _LineChartAttrs(ChartCommonAttrs):
     """The line chart attributes.
 
     Attributes:
@@ -779,7 +770,7 @@ class BarSingleChartAttrs(TypedDict):
     yerr: Union[str, None]  # the name of the yerr attribute in data
 
 
-class BarChartAttrs(ChartCommonAttrs):
+class _BarChartAttrs(ChartCommonAttrs):
     """The bar chart attributes.
 
     Attributes:
@@ -857,7 +848,7 @@ class HistogramSingleChartAttrs(TypedDict):
     x: Union[str, None]  # the name of the x attribute in data
 
 
-class HistogramChartAttrs(ChartCommonAttrs):
+class _HistogramChartAttrs(ChartCommonAttrs):
     """The histogram chart attributes.
 
     Attributes:
@@ -939,7 +930,7 @@ class HeatmapSingleChartAttrs(TypedDict):
     colorbar: Union[HeatmapColorbarAttrs, None]
 
 
-class HeatmapChartAttrs(ChartCommonAttrs):
+class _HeatmapChartAttrs(ChartCommonAttrs):
     """The heatmap chart attributes.
 
     Attributes:
@@ -1022,7 +1013,7 @@ class ScatterSingleChartAttrs(TypedDict):
     hue: Union[str, None]
 
 
-class ScatterChartAttrs(ChartCommonAttrs):
+class _ScatterChartAttrs(ChartCommonAttrs):
     """The scatter chart attributes.
 
     Attributes:
@@ -1107,7 +1098,7 @@ class BoxSingleChartAttrs(TypedDict):
     value: Union[str, None]  # the name of the value attribute in data
 
 
-class BoxChartAttrs(ChartCommonAttrs):
+class _BoxChartAttrs(ChartCommonAttrs):
     """The box plot chart attributes.
 
     Attributes:
@@ -1170,7 +1161,7 @@ class ParallelCoordsSingleChartAttrs(TypedDict):
     category_orders: Union[Dict[str, List[str]], None]
 
 
-class ParallelCoordsChartAttrs(ChartCommonAttrs):
+class _ParallelCoordsChartAttrs(ChartCommonAttrs):
     """The parallel coordinates chart attributes.
 
     Attributes:
@@ -1186,13 +1177,43 @@ class ParallelCoordsChartAttrs(ChartCommonAttrs):
 # ================================================
 
 
-ChartAttrs = Union[
-    LineChartAttrs,
-    BarChartAttrs,
-    HistogramChartAttrs,
-    HeatmapChartAttrs,
-    ScatterChartAttrs,
-    BoxChartAttrs,
-    ParallelCoordsChartAttrs,
+_ChartAttrs = Union[
+    _LineChartAttrs,
+    _BarChartAttrs,
+    _HistogramChartAttrs,
+    _HeatmapChartAttrs,
+    _ScatterChartAttrs,
+    _BoxChartAttrs,
+    _ParallelCoordsChartAttrs,
 ]
 """The union of all chart attributes."""
+
+
+# ================================================
+# Deprecated Aliases
+# ================================================
+
+
+_DEPRECATED_TYPINGS = {
+    "ChartAttrs": _ChartAttrs,
+    "LineChartAttrs": _LineChartAttrs,
+    "BarChartAttrs": _BarChartAttrs,
+    "HistogramChartAttrs": _HistogramChartAttrs,
+    "HeatmapChartAttrs": _HeatmapChartAttrs,
+    "ScatterChartAttrs": _ScatterChartAttrs,
+    "BoxChartAttrs": _BoxChartAttrs,
+    "ParallelCoordsChartAttrs": _ParallelCoordsChartAttrs,
+}
+
+
+def __getattr__(name: str):
+    # deprecated for one release (ADR 0003): the chart fronts are the API surface
+    if name in _DEPRECATED_TYPINGS:
+        warnings.warn(
+            f"datachart.typings.{name} is deprecated; the chart functions document "
+            "their parameters — see datachart.charts.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return _DEPRECATED_TYPINGS[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/datachart/utils/_internal/chart_builder.py
+++ b/datachart/utils/_internal/chart_builder.py
@@ -3,7 +3,7 @@
 This module provides helper functions to reduce boilerplate in chart definitions.
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 
 def _get_indexed_value(value: Any, index: int, is_list_type: bool = False) -> Any:
@@ -286,81 +286,3 @@ def build_charts_structure(
         ]
     else:
         return build_chart_dict_single(data, **common_args)
-
-
-def build_attrs_dict(
-    chart_type: str,
-    charts: Union[Dict[str, Any], List[Dict[str, Any]]],
-    *,
-    title: Optional[str] = None,
-    xlabel: Optional[str] = None,
-    ylabel: Optional[str] = None,
-    figsize: Any = None,
-    xmin: Any = None,
-    xmax: Any = None,
-    ymin: Any = None,
-    ymax: Any = None,
-    show_legend: Optional[bool] = None,
-    show_grid: Any = None,
-    aspect_ratio: Optional[str] = None,
-    subplots: Optional[bool] = None,
-    max_cols: Optional[int] = None,
-    sharex: Optional[bool] = None,
-    sharey: Optional[bool] = None,
-    **extra_attrs: Any,
-) -> Dict[str, Any]:
-    """Build the attrs dictionary for the internal API.
-
-    Args:
-        chart_type: The type of chart (e.g., "linechart").
-        charts: The charts structure.
-        title: The title.
-        xlabel: The x-axis label.
-        ylabel: The y-axis label.
-        figsize: The figure size.
-        xmin: The minimum x-axis value.
-        xmax: The maximum x-axis value.
-        ymin: The minimum y-axis value.
-        ymax: The maximum y-axis value.
-        show_legend: Whether to show the legend.
-        show_grid: Which grid lines to show.
-        aspect_ratio: The aspect ratio.
-        subplots: Whether to create subplots.
-        max_cols: Maximum columns in subplots.
-        sharex: Whether to share x-axis.
-        sharey: Whether to share y-axis.
-        **extra_attrs: Extra chart-specific attributes.
-
-    Returns:
-        The attrs dictionary.
-    """
-    attrs: Dict[str, Any] = {
-        "type": chart_type,
-        "charts": charts,
-    }
-
-    # Add common global attributes
-    optional_attrs = {
-        "title": title,
-        "xlabel": xlabel,
-        "ylabel": ylabel,
-        "figsize": figsize,
-        "xmin": xmin,
-        "xmax": xmax,
-        "ymin": ymin,
-        "ymax": ymax,
-        "show_legend": show_legend,
-        "show_grid": show_grid,
-        "aspect_ratio": aspect_ratio,
-        "subplots": subplots,
-        "max_cols": max_cols,
-        "sharex": sharex,
-        "sharey": sharey,
-        **extra_attrs,
-    }
-
-    for key, value in optional_attrs.items():
-        if value is not None:
-            attrs[key] = value
-
-    return attrs

--- a/datachart/utils/_internal/layers.py
+++ b/datachart/utils/_internal/layers.py
@@ -51,7 +51,7 @@ from .config_helpers import (
     configure_axis_limits,
 )
 from ..stats import minimum, maximum
-from ...constants import ORIENTATION, VALFMT
+from ...constants import ASPECT_RATIO, ORIENTATION, VALFMT
 from ...config import config
 
 DEFAULT_NUM_BINS = 20
@@ -1489,7 +1489,11 @@ def build_chart_panel_settings(
         "xmax": settings.get("xmax"),
         "ymin": settings.get("ymin"),
         "ymax": settings.get("ymax"),
-        "aspect_ratio": settings.get("aspect_ratio"),
+        "aspect_ratio": (
+            ASPECT_RATIO.AUTO
+            if settings.get("aspect_ratio") is None
+            else settings["aspect_ratio"]
+        ),
         "legend_style": get_legend_style(),
         "bar_width": config["plot_bar_width"],
         "bar_mode": settings.get("bar_mode") or "group",

--- a/datachart/utils/_internal/plot_engine.py
+++ b/datachart/utils/_internal/plot_engine.py
@@ -1,13 +1,14 @@
 """Figure assembly for the chart fronts.
 
-`render_chart` turns a chart front's attrs dict into a rendered figure: it
-builds the layers (resolving style at construction), assembles one panel per
-coordinate space, renders them, and stores the metadata transport
-(`figure._chart_metadata`) that composition functions consume.
+`render_chart` turns a chart front's charts structure and settings into a
+rendered figure: it builds the layers (resolving style at construction),
+assembles one panel per coordinate space, renders them, and stores the
+metadata transport (`figure._chart_metadata`) that composition functions
+consume.
 """
 
 import warnings
-from typing import List
+from typing import Dict, List, Union
 
 import matplotlib.pyplot as plt
 
@@ -19,268 +20,53 @@ from .layers import (
     group_from_chart,
     build_chart_panel_settings,
 )
-from ...constants import FIG_SIZE, ASPECT_RATIO, ORIENTATION
-from ...typings import ChartAttrs
-
-# ------------------------------------------------
-# Settings Mapping and Helpers
-# ------------------------------------------------
-
-
-settings_attr_mapping = [
-    # common attributes
-    {"name": "type", "default": None},
-    {"name": "title", "default": None},
-    {"name": "xlabel", "default": None},
-    {"name": "ylabel", "default": None},
-    {"name": "figsize", "default": FIG_SIZE.DEFAULT},
-    {"name": "xmin", "default": None},
-    {"name": "xmax", "default": None},
-    {"name": "ymin", "default": None},
-    {"name": "ymax", "default": None},
-    {"name": "aspect_ratio", "default": ASPECT_RATIO.AUTO},
-    {"name": "subplots", "default": None},
-    {"name": "max_cols", "default": 4},
-    {"name": "sharex", "default": False},
-    {"name": "sharey", "default": False},
-    # visibility attributes
-    {"name": "show_legend", "default": None},
-    {"name": "show_grid", "default": None},
-    {"name": "show_yerr", "default": None},
-    {"name": "show_values", "default": None},
-    {"name": "show_area", "default": None},
-    {"name": "show_density", "default": None},
-    {"name": "show_cumulative", "default": None},
-    {"name": "show_colorbars", "default": None},
-    {"name": "show_heatmap_values", "default": None},
-    {"name": "show_regression", "default": None},
-    {"name": "show_ci", "default": None},
-    {"name": "show_correlation", "default": None},
-    {"name": "show_outliers", "default": None},
-    {"name": "show_notch", "default": None},
-    # chart specific attributes
-    {"name": "orientation", "default": None},
-    {"name": "scalex", "default": None},
-    {"name": "scaley", "default": None},
-    {"name": "num_bins", "default": None},
-    {"name": "ci_level", "default": None},
-    {"name": "size_range", "default": None},
-    {"name": "value_format", "default": None},
-    {"name": "bar_mode", "default": None},
-]
-
-settings_chart_mapping = [
-    "aspect_ratio",
-    "xmin",
-    "xmax",
-    "ymin",
-    "ymax",
-    "show_legend",
-    "show_grid",
-    "show_yerr",
-    "show_values",
-    "show_area",
-    "show_density",
-    "show_cumulative",
-    "show_colorbars",
-    "show_heatmap_values",
-    "show_regression",
-    "show_ci",
-    "show_correlation",
-    "show_outliers",
-    "show_notch",
-    "orientation",
-    "scalex",
-    "scaley",
-    "num_bins",
-    "ci_level",
-    "size_range",
-    "value_format",
-    "bar_mode",
-]
-
-SUPPORTED_SETTINGS = {
-    "linechart": [
-        "xmin",
-        "xmax",
-        "ymin",
-        "ymax",
-        "aspect_ratio",
-        "show_legend",
-        "show_grid",
-        "show_yerr",
-        "show_area",
-        "scalex",
-        "scaley",
-    ],
-    "barchart": [
-        "aspect_ratio",
-        "xmin",
-        "xmax",
-        "ymin",
-        "ymax",
-        "show_legend",
-        "show_grid",
-        "show_yerr",
-        "show_values",
-        "value_format",
-        "orientation",
-        "scalex",
-        "scaley",
-        "bar_mode",
-    ],
-    "histogram": [
-        "aspect_ratio",
-        "xmin",
-        "xmax",
-        "ymin",
-        "ymax",
-        "show_legend",
-        "show_grid",
-        "show_density",
-        "show_cumulative",
-        "num_bins",
-        "orientation",
-        "scalex",
-        "scaley",
-    ],
-    "heatmap": [
-        "aspect_ratio",
-        "xmin",
-        "xmax",
-        "ymin",
-        "ymax",
-        "show_grid",
-        "show_colorbars",
-        "show_heatmap_values",
-    ],
-    "scatterchart": [
-        "xmin",
-        "xmax",
-        "ymin",
-        "ymax",
-        "aspect_ratio",
-        "show_legend",
-        "show_grid",
-        "show_regression",
-        "show_ci",
-        "ci_level",
-        "show_correlation",
-        "scalex",
-        "scaley",
-        "size_range",
-    ],
-    "boxplot": [
-        "aspect_ratio",
-        "xmin",
-        "xmax",
-        "ymin",
-        "ymax",
-        "show_legend",
-        "show_grid",
-        "show_outliers",
-        "show_notch",
-        "orientation",
-        "scaley",
-    ],
-    "parallelcoords": [
-        "aspect_ratio",
-        "show_legend",
-        "show_grid",
-    ],
-}
-
-
-def get_settings(attrs: dict) -> dict:
-    """Get the chart settings.
-
-    Args:
-        attrs: The attributes.
-
-    Returns:
-        The chart settings.
-
-    """
-
-    return {
-        attr["name"]: attrs.get(attr["name"], attr["default"])
-        for attr in settings_attr_mapping
-    }
-
-
-def get_chart_settings(settings: dict) -> dict:
-    """Get the chart settings.
-
-    Args:
-        settings: The chart settings.
-
-    Returns:
-        The chart settings without the `None` values.
-
-    """
-
-    return {key: val for key, val in settings.items() if key in settings_chart_mapping}
-
-
-def assert_chart_settings(settings: dict, supported_settings: List[str]) -> None:
-    """Assert that the chart config is supported.
-
-    Args:
-        settings: The chart settings.
-        supported_settings: The supported settings.
-
-    """
-
-    for key, val in settings.items():
-        if key not in supported_settings and val:
-            warnings.warn(
-                f"Settings['{key}'] is present but is not supported. Ignoring flag..."
-            )
-
+from ...constants import FIG_SIZE, ORIENTATION
 
 # ================================================
 # Chart Rendering
 # ================================================
 
 
-def render_chart(attrs: ChartAttrs) -> plt.Figure:
-    """Render a chart front's attrs dict into a figure via the Layer/Panel seam.
+def render_chart(
+    chart_type: str,
+    charts: Union[Dict, List[Dict]],
+    settings: dict,
+) -> plt.Figure:
+    """Render a chart front's charts and settings into a figure via the Layer/Panel seam.
 
     Args:
-        attrs: The chart attributes.
+        chart_type: The chart type, e.g. `"linechart"`.
+        charts: The charts structure built by `build_charts_structure`.
+        settings: The figure-level settings forwarded by the chart front;
+            values may be `None`, in which case defaults apply at point of use.
 
     Returns:
         The rendered figure.
 
     """
 
-    if not isinstance(attrs["charts"], dict) and not isinstance(attrs["charts"], list):
-        raise ValueError("Parameter `attrs['charts']` is not correctly structured")
+    if not isinstance(charts, (dict, list)):
+        raise ValueError("Parameter `charts` is not correctly structured")
 
-    settings = get_settings(attrs)
-    chart_type = settings["type"]
-
-    assert_chart_settings(
-        settings=get_chart_settings(settings),
-        supported_settings=SUPPORTED_SETTINGS[chart_type],
-    )
-
-    charts = attrs.get("charts")
     charts = charts if isinstance(charts, list) else [charts]
 
     # build the layers; style is resolved against the config here, once
     layers = build_layers(chart_type, charts, settings)
 
+    max_cols = settings.get("max_cols")
     subplot_config = get_subplot_config(
         chart_type,
-        settings["subplots"],
+        settings.get("subplots"),
         n_charts=len(charts),
-        max_cols=settings["max_cols"],
+        max_cols=4 if max_cols is None else max_cols,
     )
+    figsize = settings.get("figsize")
+    sharex = settings.get("sharex")
+    sharey = settings.get("sharey")
     figure, axes = plt.subplots(
-        figsize=settings["figsize"],
-        sharex=settings["sharex"],
-        sharey=settings["sharey"],
+        figsize=FIG_SIZE.DEFAULT if figsize is None else figsize,
+        sharex=False if sharex is None else sharex,
+        sharey=False if sharey is None else sharey,
         constrained_layout=True,
         squeeze=False,
         **subplot_config,
@@ -301,7 +87,7 @@ def render_chart(attrs: ChartAttrs) -> plt.Figure:
         )
         panel.render(axes[0])
     else:
-        if settings["show_legend"] and chart_type != "heatmap":
+        if settings.get("show_legend") and chart_type != "heatmap":
             warnings.warn("The `show_legend` flag will be ignored for multi-subplots.")
 
         # histograms share bin edges across all subplots

--- a/docs/adr/0003-explicit-settings-seam.md
+++ b/docs/adr/0003-explicit-settings-seam.md
@@ -1,0 +1,50 @@
+---
+status: accepted
+---
+
+# Chart fronts pass explicit settings; the attrs dict is retired
+
+Every chart front packs its ~30 keyword arguments into one attrs dict
+(`build_attrs_dict`) that `render_chart` immediately unpacks again through
+three bookkeeping tables (`settings_attr_mapping`, `settings_chart_mapping`,
+`SUPPORTED_SETTINGS`) plus `get_settings`/`assert_chart_settings`. Since the
+transport slimming, the attrs dict has exactly one consumer — `render_chart` —
+and the `SUPPORTED_SETTINGS` warnings are unreachable from the public API
+because each front's fixed signature already forbids unsupported flags. The
+hop is a pure middle-man: parameters are named in the signature, forwarded
+into a dict, then re-extracted against a defaults table.
+
+We retire it: fronts call `render_chart(chart_type, charts, settings)` with
+the charts structure and an explicit settings dict. No behavior change —
+golden parity must hold.
+
+## Commitments
+
+- **`render_chart` stays the single assembly point** for subplot layout,
+  panel construction, and the metadata transport. Fronts do not build layers.
+- **The front signatures are the allowlist.** `build_attrs_dict`,
+  `get_settings`, `assert_chart_settings`, and all three mapping tables are
+  deleted. A chart supports a setting iff its front names the parameter.
+- **Defaults apply at the point of use**: `figsize=FIG_SIZE.DEFAULT` and
+  `max_cols=4` inside `render_chart`, `aspect_ratio=AUTO` where the panel
+  settings are built (`build_chart_panel_settings`). Public
+  signatures keep `None` = "resolve downstream"; no promotion into signature
+  defaults.
+- **Signatures stay explicit and per-front.** The ~20 common parameters
+  repeated across the 7 fronts are declarative API surface, kept; only the
+  body forwarding is deduplicated (each parameter forwarded once). No
+  `**kwargs` machinery.
+- **`ChartAttrs` and the 7 `*ChartAttrs` TypedDicts are deprecated**, not
+  removed: a module `__getattr__` in `datachart/typings.py` emits
+  `DeprecationWarning` for one release (the `OverlayChart` precedent). The
+  `*SingleChartAttrs` chart-dict types stay untouched. Docs repoint: notebook
+  "for more details" links and `references/typings.md` entries move to the
+  chart-function reference (`references/charts.md`).
+
+## Considered options
+
+Having fronts build layers directly (retiring `render_chart` down to a figure
+helper) was rejected: it would spread subplot/transport logic across 7 files.
+Keeping the attrs dict but inlining `get_settings` was rejected as preserving
+the middle-man. Shared `**common_kwargs` for the repeated parameters was
+rejected: it destroys IDE discoverability and per-chart typing.

--- a/docs/how-to-guides/charts/barchart.ipynb
+++ b/docs/how-to-guides/charts/barchart.ipynb
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more details, see the [datachart.typings.BarChartAttrs](/references/typings/#datachart.typings.BarChartAttrs) type."
+    "For more details, see the [datachart.charts.BarChart](/references/charts/#datachart.charts.BarChart) function."
    ]
   },
   {

--- a/docs/how-to-guides/charts/boxplot.ipynb
+++ b/docs/how-to-guides/charts/boxplot.ipynb
@@ -97,7 +97,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "For more details, see the [datachart.typings.BoxChartAttrs](/references/typings/#datachart.typings.BoxChartAttrs) type."
+        "For more details, see the [datachart.charts.BoxPlot](/references/charts/#datachart.charts.BoxPlot) function."
       ]
     },
     {

--- a/docs/how-to-guides/charts/heatmap.ipynb
+++ b/docs/how-to-guides/charts/heatmap.ipynb
@@ -86,7 +86,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more details, see the [datachart.typings.HeatmapChartAttrs](/references/typings/#datachart.typings.HeatmapChartAttrs) type."
+    "For more details, see the [datachart.charts.Heatmap](/references/charts/#datachart.charts.Heatmap) function."
    ]
   },
   {

--- a/docs/how-to-guides/charts/histogram.ipynb
+++ b/docs/how-to-guides/charts/histogram.ipynb
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more details, see the [datachart.typings.HistogramChartAttrs](/references/typings/#datachart.typings.HistogramChartAttrs) type."
+    "For more details, see the [datachart.charts.Histogram](/references/charts/#datachart.charts.Histogram) function."
    ]
   },
   {

--- a/docs/how-to-guides/charts/linechart.ipynb
+++ b/docs/how-to-guides/charts/linechart.ipynb
@@ -90,7 +90,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more details, see the [datachart.typings.LineChartAttrs](/references/typings/#datachart.typings.LineChartAttrs) type."
+    "For more details, see the [datachart.charts.LineChart](/references/charts/#datachart.charts.LineChart) function."
    ]
   },
   {

--- a/docs/how-to-guides/charts/parallelcoords.ipynb
+++ b/docs/how-to-guides/charts/parallelcoords.ipynb
@@ -90,7 +90,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "For more details, see the [datachart.typings.ParallelCoordsChartAttrs](/references/typings/#datachart.typings.ParallelCoordsChartAttrs) type."
+        "For more details, see the [datachart.charts.ParallelCoords](/references/charts/#datachart.charts.ParallelCoords) function."
       ]
     },
     {

--- a/docs/how-to-guides/charts/scatterchart.ipynb
+++ b/docs/how-to-guides/charts/scatterchart.ipynb
@@ -101,7 +101,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "For more details, see the [datachart.typings.ScatterChartAttrs](/references/typings/#datachart.typings.ScatterChartAttrs) type.\n"
+        "For more details, see the [datachart.charts.ScatterChart](/references/charts/#datachart.charts.ScatterChart) function.\n"
       ]
     },
     {

--- a/docs/references/typings.md
+++ b/docs/references/typings.md
@@ -15,10 +15,6 @@ title: Typings Module
 
 ### Common Chart Typings
 
-::: datachart.typings.ChartAttrs
-    options:
-        heading_level: 4
-
 ::: datachart.typings.ChartCommonAttrs
     options:
         heading_level: 4
@@ -33,10 +29,6 @@ title: Typings Module
 
 ### Line Chart Typings
 
-::: datachart.typings.LineChartAttrs
-    options:
-        heading_level: 4
-
 ::: datachart.typings.LineSingleChartAttrs
     options:
         heading_level: 4
@@ -46,10 +38,6 @@ title: Typings Module
         heading_level: 4
 
 ### Bar Chart Typings
-
-::: datachart.typings.BarChartAttrs
-    options:
-        heading_level: 4
 
 ::: datachart.typings.BarSingleChartAttrs
     options:
@@ -61,10 +49,6 @@ title: Typings Module
 
 ### Histogram Typings
 
-::: datachart.typings.HistogramChartAttrs
-    options:
-        heading_level: 4
-
 ::: datachart.typings.HistogramSingleChartAttrs
     options:
         heading_level: 4
@@ -74,10 +58,6 @@ title: Typings Module
         heading_level: 4
 
 ### Heatmap Typings
-
-::: datachart.typings.HeatmapChartAttrs
-    options:
-        heading_level: 4
 
 ::: datachart.typings.HeatmapSingleChartAttrs
     options:
@@ -90,10 +70,6 @@ title: Typings Module
 
 ### Scatter Chart Typings
 
-::: datachart.typings.ScatterChartAttrs
-    options:
-        heading_level: 4
-
 ::: datachart.typings.ScatterSingleChartAttrs
     options:
         heading_level: 4
@@ -105,10 +81,6 @@ title: Typings Module
 
 ### Box Chart (Box Plot) Typings
 
-::: datachart.typings.BoxChartAttrs
-    options:
-        heading_level: 4
-
 ::: datachart.typings.BoxSingleChartAttrs
     options:
         heading_level: 4
@@ -119,10 +91,6 @@ title: Typings Module
 
 
 ### Parallel Coordinates Plot Typings
-
-::: datachart.typings.ParallelCoordsChartAttrs
-    options:
-        heading_level: 4
 
 ::: datachart.typings.ParallelCoordsSingleChartAttrs
     options:

--- a/test/test_typings.py
+++ b/test/test_typings.py
@@ -1,0 +1,42 @@
+"""Tests for the deprecated chart-attrs typings (ADR 0003)."""
+
+import warnings
+
+import pytest
+
+DEPRECATED_NAMES = [
+    "ChartAttrs",
+    "LineChartAttrs",
+    "BarChartAttrs",
+    "HistogramChartAttrs",
+    "HeatmapChartAttrs",
+    "ScatterChartAttrs",
+    "BoxChartAttrs",
+    "ParallelCoordsChartAttrs",
+]
+
+
+class TestDeprecatedChartAttrs:
+    """The retired chart-attrs typings warn but still resolve."""
+
+    @pytest.mark.parametrize("name", DEPRECATED_NAMES)
+    def test_access_warns_and_returns_type(self, name):
+        import datachart.typings as typings
+
+        with pytest.warns(DeprecationWarning, match="datachart.charts"):
+            attr = getattr(typings, name)
+        assert attr is not None
+
+    def test_single_chart_attrs_stay_public(self):
+        import datachart.typings as typings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            assert typings.LineSingleChartAttrs is not None
+            assert typings.BarSingleChartAttrs is not None
+
+    def test_unknown_name_raises_attribute_error(self):
+        import datachart.typings as typings
+
+        with pytest.raises(AttributeError):
+            typings.DoesNotExist


### PR DESCRIPTION
## Summary
Retires the attrs-dict hop between the chart fronts and the plot engine (ADR 0003): each front now calls `render_chart(chart_type, charts, settings)` with an explicit settings dict, so the front signatures are the single allowlist of what each chart supports. No behavior change — golden parity holds.

## Changes
- `render_chart` takes `(chart_type, charts, settings)`; `None` settings resolve to defaults at point of use (`figsize`, `max_cols`, `sharex`/`sharey` in `render_chart`; `aspect_ratio` in `build_chart_panel_settings`)
- Deleted `build_attrs_dict`, `get_settings`, `get_chart_settings`, `assert_chart_settings`, and the three mapping tables (`settings_attr_mapping`, `settings_chart_mapping`, `SUPPORTED_SETTINGS`) — the `SUPPORTED_SETTINGS` warnings were unreachable from the public API
- All 7 chart fronts build a settings dict literal; public signatures, docstrings, and behavior unchanged
- `ChartAttrs` and the 7 `*ChartAttrs` TypedDicts deprecated for one release behind a module `__getattr__` in `datachart.typings` (the `OverlayChart` precedent); `*SingleChartAttrs` untouched; deprecation covered by `test/test_typings.py`
- Docs: `references/typings.md` drops the deprecated entries; the 7 chart notebooks' "for more details" links repoint to the chart-function reference (JSON edited surgically, not re-executed)
- ADR 0003 committed; CONTEXT.md "Chart front" entry and CLAUDE.md chart-creation flow updated to match

## Test plan
- `python test/golden/golden.py baseline` (on main) then `candidate` (after refactor) → 43/43 pixel-identical, zero diffs
- `uv run --with pytest python -m pytest test/ -q` → 86 passed
- `python -m unittest discover test` → OK (36 tests; pytest-style files not collected, same as on main)
- `uv run --with black python -m black datachart` → clean on all touched files
- `dev-tools:code-review` vs main (Standards + Spec axes) → no missing requirements, no scope creep; flagged nits (stale CLAUDE.md flow, mixed None-default idioms, ADR wording on the `aspect_ratio` default location) fixed before commit

Decisions taken autonomously: black's incidental blank-line reformat of 5 files untouched by this task was reverted to keep the diff scoped; `None`-defaults use explicit `is None` checks so falsy user values pass through exactly as on main.
