### PR TITLE
fix: repair composition colors, grid subplot layout, publication palette, and empty legends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Notebook tests validate all documentation examples to ensure they execute withou
 
 ### Color Cycles
 
-The `create_color_cycle()` function in `colors.py` creates cycle-backed color lookups from palette names or color lists. A `Panel` builds one cycle per `LayerGroup` (singular palette for subplots, multiple palette otherwise) and hands each layer its color through the `DrawContext`.
+The `create_color_cycle()` function in `colors.py` creates cycle-backed color lookups from palette names or color lists. A `Panel` builds one cycle per palette, pooled across its `LayerGroup`s (singular palette for subplots, multiple palette otherwise), so composed single-series figures draw in distinct colors; each layer receives its color through the `DrawContext`.
 
 ### Subplot Management
 

--- a/datachart/themes/publication.py
+++ b/datachart/themes/publication.py
@@ -11,8 +11,10 @@ from ..constants import (
 PUBLICATION_THEME: StyleAttrs = {
     # general color style
     "color_general_singular": COLORS.Blues,
-    "color_general_multiple": COLORS.YlGnBu,
-    "color_parallel_hue": COLORS.YlGnBu,
+    # dark half of YlGnBu, contrast-ordered: the colormap's pale yellow end
+    # is illegible on white
+    "color_general_multiple": ["#0c2c84", "#41b6c4", "#225ea8", "#7fcdbb", "#1d91c0"],
+    "color_parallel_hue": ["#0c2c84", "#41b6c4", "#225ea8", "#7fcdbb", "#1d91c0"],
     # general font style
     "font_general_family": "sans-serif",
     "font_general_sansserif": ["Helvetica", "Arial", "DejaVu Sans"],

--- a/datachart/utils/_internal/layers.py
+++ b/datachart/utils/_internal/layers.py
@@ -10,6 +10,7 @@ frozen DrawContext with its per-layer instructions.
 
 import json
 import warnings
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import List, Optional, Union
 
@@ -1280,12 +1281,30 @@ class Panel:
         zorder_defaults = s.get("zorder_defaults", {})
 
         # draw the layers group by group, in order
+        # one color cycle per palette, pooled across the panel's groups, so
+        # composed single-series figures draw in distinct colors
+        def palette_key(group):
+            return (
+                tuple(group.palette)
+                if isinstance(group.palette, list)
+                else group.palette
+            )
+
+        pooled_colors = defaultdict(int)
+        for group in self.groups:
+            pooled_colors[palette_key(group)] += group.max_colors
+        cycles = {}
+        for group in self.groups:
+            key = palette_key(group)
+            if key not in cycles:
+                cycles[key] = create_color_cycle(group.palette, pooled_colors[key])
+
         group_axes = []
         for group, assignment in zip(self.groups, assignments):
             target_ax = ax_right if assignment == "right" else ax
             group_axes.append(target_ax)
 
-            cycle = create_color_cycle(group.palette, group.max_colors)
+            cycle = cycles[palette_key(group)]
             bins = s.get("hist_bins_override")
             if bins is None:
                 bins = group.hist_bins()

--- a/datachart/utils/_internal/layers.py
+++ b/datachart/utils/_internal/layers.py
@@ -1435,8 +1435,10 @@ class Panel:
             elif s.get("legend_mode") == "combined":
                 self._combine_legends(ax, ax_right, legend_style)
             elif not any(isinstance(l, ParallelCoordsLayer) for l in layers):
-                # parallel coords only carry a legend when hue groups exist
-                ax.legend(title="Legend", **legend_style)
+                # parallel coords only carry a legend when hue groups exist;
+                # unlabeled panels get no empty legend frame
+                if ax.get_legend_handles_labels()[1]:
+                    ax.legend(title="Legend", **legend_style)
 
     def _apply_bar_ticks(self, ax, bar_ticks, slot_width, bar_layers) -> None:
         is_horizontal = bar_layers[0].is_horizontal

--- a/datachart/utils/_internal/plot_engine.py
+++ b/datachart/utils/_internal/plot_engine.py
@@ -149,4 +149,33 @@ def render_chart(
         ),
     }
 
+    # multi-subplot figures also carry one panel per subplot, so grids can
+    # rebuild the subplot arrangement inside a cell
+    if not is_single_plot:
+        subplot_panels = []
+        for layer in layers:
+            sub_settings = build_chart_panel_settings(
+                chart_type, settings, "composition", layer.style
+            )
+            sub_settings["show_legend"] = False
+            sub_settings["bar_slotting"] = False
+            sub_settings["bar_ticks"] = "subplot"
+            sub_settings["hist_bins_override"] = hist_bins
+            sub_settings["title"] = layer.chart.get("subtitle")
+            xlabel, ylabel = layer.chart.get("xlabel"), layer.chart.get("ylabel")
+            if is_horizontal_bar:
+                xlabel, ylabel = ylabel, xlabel
+            sub_settings["xlabel"] = xlabel
+            sub_settings["ylabel"] = ylabel
+            subplot_panels.append(
+                Panel(
+                    [group_from_chart([layer], settings, mode="singular")], sub_settings
+                )
+            )
+        figure._chart_metadata["panels"] = subplot_panels
+        figure._chart_metadata["shape"] = (
+            subplot_config["nrows"],
+            subplot_config["ncols"],
+        )
+
     return figure

--- a/datachart/utils/figure.py
+++ b/datachart/utils/figure.py
@@ -163,6 +163,20 @@ def _figure_grid_layout_impl(
             target_ax.axis("off")
             continue
 
+        # a multi-subplot figure rebuilds its subplot arrangement in the cell
+        subplot_panels = metadata.get("panels")
+        if subplot_panels and len(subplot_panels) > 1:
+            nrows_sub, ncols_sub = metadata.get("shape", (1, len(subplot_panels)))
+            sub_gs = target_ax.get_subplotspec().subgridspec(nrows_sub, ncols_sub)
+            target_ax.remove()
+            for p_idx, subplot_panel in enumerate(subplot_panels):
+                sub_ax = combined_fig.add_subplot(
+                    sub_gs[p_idx // ncols_sub, p_idx % ncols_sub]
+                )
+                sub_ax.axis("off")
+                subplot_panel.render(sub_ax)
+            continue
+
         target_ax.axis("off")
         panel.render(target_ax)
 

--- a/test/golden/golden.py
+++ b/test/golden/golden.py
@@ -49,6 +49,8 @@ EXPECTED_CHANGES = {
     # publication multiple palette drops YlGnBu's illegible pale end
     "theme_publication_line",
     "overlay_theme_snapshot",
+    # no empty legend frame when nothing carries a label
+    "theme_greyscale_bar",
 }
 
 

--- a/test/golden/golden.py
+++ b/test/golden/golden.py
@@ -44,6 +44,8 @@ EXPECTED_CHANGES = {
     "overlay_bar_bar_line",
     "overlay_hist_hist",
     "grid_with_overlay",
+    # grids rebuild a subplot figure's arrangement inside its cell
+    "grid_subplot_figure",
 }
 
 

--- a/test/golden/golden.py
+++ b/test/golden/golden.py
@@ -46,6 +46,9 @@ EXPECTED_CHANGES = {
     "grid_with_overlay",
     # grids rebuild a subplot figure's arrangement inside its cell
     "grid_subplot_figure",
+    # publication multiple palette drops YlGnBu's illegible pale end
+    "theme_publication_line",
+    "overlay_theme_snapshot",
 }
 
 

--- a/test/golden/golden.py
+++ b/test/golden/golden.py
@@ -32,12 +32,18 @@ from datachart.utils import OverlayChart, FigureGridLayout
 from datachart.config import config
 from datachart.constants import THEME
 
-# Cases where the refactor intentionally changes output (ADR 0001).
+# Cases whose output intentionally changed since the last published baseline.
 EXPECTED_CHANGES = {
-    "overlay_bar_bar",          # bar collision fix: cross-layer group offsets
-    "overlay_bar_bar_line",     # cross-layer bar counting
-    "overlay_hist_hist",        # overlay alpha now counts hists across the panel
-    "grid_theme_mutation",      # grid renders with construction-time style, not current config
+    # panel-wide palette pooling: composed figures get distinct colors
+    "overlay_line_line",
+    "overlay_line_bar_dual",
+    "overlay_auto_assign",
+    "overlay_hist_line",
+    "overlay_zorder_grid",
+    "overlay_bar_bar",
+    "overlay_bar_bar_line",
+    "overlay_hist_hist",
+    "grid_with_overlay",
 }
 
 


### PR DESCRIPTION
## Summary

A visual audit of the golden-image harness (43 cases) surfaced four rendering defects around composition and themes. Each is fixed in its own commit, verified through the golden loop.

## Changes

- **Overlay colors**: `Panel.render` now pools one color cycle per palette across its layer groups, so same-type composed figures (line+line, bar+bar, hist+hist) draw in distinct colors instead of all sampling the identical palette-end color. Single-group panels are unchanged; construction-time style freezing is preserved (`overlay_theme_snapshot` still renders per-theme colors).
- **Grid composition**: the metadata transport of a multi-subplot figure now also carries one panel per subplot plus the subplot shape, and grids rebuild the arrangement in a nested gridspec instead of collapsing all layers into one axes under the first subplot's title. Panel/overlay composition keeps consuming the merged panel.
- **Publication theme**: `color_general_multiple`/`color_parallel_hue` switch from end-to-end YlGnBu colormap sampling (first series was near-invisible pale yellow on white) to an explicit contrast-ordered list from YlGnBu's dark half.
- **Legends**: `show_legend=True` with no labeled handles no longer draws an empty framed "Legend" box.
- Golden harness `EXPECTED_CHANGES` updated per fix; CLAUDE.md color-cycle seam description updated.

## Test plan

- `python test/golden/golden.py candidate` → 43/43 rendered, 43 identical against the post-fix baseline, 0 unexpected changes; each fix's expected diffs were visually inspected before promoting the baseline.
- `python -m unittest discover test` → 36 passed.
- `black --check` clean on all touched files.
- Notebook tests (`pytest --nbmake`) not run here; covered by the pre-push hook.
