### PR TITLE
fix(line): fill the area under the line down to the axis floor

### DIFF
--- a/datachart/utils/_internal/layers.py
+++ b/datachart/utils/_internal/layers.py
@@ -63,6 +63,9 @@ DEFAULT_VALUE_FORMAT = VALUE_FORMAT.DEFAULT
 DEFAULT_CI_LEVEL = 0.95
 DEFAULT_SIZE_RANGE = (20, 200)
 DEFAULT_BAR_VALUE_FORMAT = "%g"
+# show_area fills this many data magnitudes below the line; the axes clip it,
+# so the fill meets the floor whatever limits sharey, ymin or a re-render set
+AREA_FLOOR_FACTOR = 1e6
 # emphasis roles (ADR 0009): background mutes, highlight bolds, None is today
 EMPHASIS_BACKGROUND = EMPHASIS.BACKGROUND
 EMPHASIS_HIGHLIGHT = EMPHASIS.HIGHLIGHT
@@ -345,12 +348,24 @@ class LineLayer(Layer):
         if draw_yerr:
             ax.fill_between(x, y - yerr, y + yerr, **self._resolved_area_style(ctx))
 
+        ax.plot(x, y, **line_style, label=self.label(ctx))
+
         if self.show_area:
             drawstyle = line_style.get("drawstyle", "")
             step = drawstyle.split("-")[1] if "steps-" in drawstyle else None
-            ax.fill_between(x, y, step=step, **self._resolved_area_style(ctx))
+            self._fill_to_floor(ax, x, y, step, self._resolved_area_style(ctx))
 
-        ax.plot(x, y, **line_style, label=self.label(ctx))
+    def _fill_to_floor(self, ax, x, y, step, area_style):
+        """Fill under the line past any plausible axis floor, outside the autoscale."""
+
+        values = np.asarray(y, dtype=float)
+        values = values[np.isfinite(values)]
+        if values.size == 0:
+            return
+        floor = values.min() - AREA_FLOOR_FACTOR * max(np.abs(values).max(), 1.0)
+        data_lim = ax.dataLim.frozen()
+        ax.fill_between(x, y, floor, step=step, **area_style)
+        ax.dataLim.set(data_lim)
 
 
 class BarLayer(Layer):

--- a/test/golden/golden.py
+++ b/test/golden/golden.py
@@ -45,6 +45,8 @@ EXPECTED_CHANGES = {
     "emphasis_hist_reference",
     "emphasis_box_labels",
     "emphasis_panel_cross_type",
+    # show_area now fills down to the axis floor instead of y=0
+    "line_area_styled",
 }
 
 

--- a/test/test_line_area.py
+++ b/test/test_line_area.py
@@ -1,0 +1,74 @@
+"""The line chart's `show_area` fill reaches the bottom of the axes."""
+
+import warnings
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pytest
+from matplotlib.collections import PolyCollection
+
+from datachart.charts import LineChart
+from datachart.constants import SCALE
+
+TEMPERATURES = [{"x": i, "y": y} for i, y in enumerate([-0.5, 0.4, 2.9, 6.3, 10.6])]
+
+
+@pytest.fixture(autouse=True)
+def _close_figures():
+    yield
+    plt.close("all")
+
+
+def _fill_bottom(ax):
+    fills = [c for c in ax.collections if isinstance(c, PolyCollection)]
+    assert len(fills) == 1
+    return min(v[1] for path in fills[0].get_paths() for v in path.vertices)
+
+
+def test_area_reaches_axis_bottom_with_negative_values():
+    fig = LineChart(data=TEMPERATURES, show_area=True)
+    ax = fig.axes[0]
+    assert _fill_bottom(ax) <= ax.get_ylim()[0]
+
+
+def test_area_does_not_change_autoscaled_limits():
+    plain = LineChart(data=TEMPERATURES).axes[0].get_ylim()
+    filled = LineChart(data=TEMPERATURES, show_area=True).axes[0].get_ylim()
+    assert filled == plain
+
+
+def test_area_reaches_explicit_ymin():
+    fig = LineChart(data=TEMPERATURES, show_area=True, ymin=-20)
+    ax = fig.axes[0]
+    assert ax.get_ylim()[0] == -20
+    assert _fill_bottom(ax) <= -20
+
+
+def test_area_reaches_shared_bottom_across_subplots():
+    fig = LineChart(
+        data=[TEMPERATURES, [{"x": i, "y": y - 30} for i, y in enumerate(range(5))]],
+        show_area=True,
+        subplots=True,
+        sharey=True,
+    )
+    axes = fig.axes[:2]
+    assert axes[0].get_ylim() == axes[1].get_ylim()
+    for ax in axes:
+        assert _fill_bottom(ax) <= ax.get_ylim()[0]
+
+
+def test_area_renders_on_log_scale_without_warnings():
+    fig = LineChart(
+        data=[{"x": i, "y": 10**i} for i in range(1, 5)],
+        show_area=True,
+        scaley=SCALE.LOG,
+    )
+    ax = fig.axes[0]
+    assert ax.get_yscale() == "log"
+    assert ax.get_ylim()[0] > 0
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        fig.canvas.draw()
+    assert _fill_bottom(ax) <= ax.get_ylim()[0]


### PR DESCRIPTION
## Summary
`show_area` on a line chart filled between the line and `y=0` (matplotlib's `fill_between` default baseline), so the fill stopped at zero and flipped above the line wherever the data went negative. The fill now always reaches the bottom of the axes, whatever the limits end up being.

## Changes
- `LineLayer.draw` draws the line first, then `_fill_to_floor` fills from the line down to a floor far below the data (`AREA_FLOOR_FACTOR = 1e6` × the series' magnitude) and lets the axes clip it — so the fill meets the axis floor under autoscaling, explicit `ymin`, `sharey` subplots (whose limits are only final after every panel renders), a log `scaley` (applied after layers draw) and Panel/Grid re-renders alike, without the layer having to know the limits.
- The axes' data limits are restored after the fill, so the oversized polygon never widens the autoscaled range; the y-range of a chart with `show_area` is identical to the same chart without it.
- `test/test_line_area.py` covers negative data, unchanged autoscale, explicit `ymin`, `sharey` subplots and warning-free log-scale rendering; `line_area_styled` is listed in the golden harness's `EXPECTED_CHANGES`.

Follow-up: the line chart guide (#44) describes `show_area` as "between the line and `y=0`"; that prose needs a one-line update once this merges.

## Test plan
- `pytest test/test_line_area.py` → 3 failed / 2 passed on the old code, 5 passed after the fix
- `pytest test --ignore=test/golden` → 181 passed
- `python -m black --check datachart` → unchanged
- `python test/golden/golden.py baseline` (on `main`) then `candidate` (on this branch) → 53 identical, only `line_area_styled` differs (fill now reaches the axis floor)
- Rendered and inspected: negative temperatures with step draw style, `sharey` subplots, log scale, `ymin=-20` at dpi=300, a series offset by 1e6 (fill spans ~1e12 data units; matplotlib clips in user coordinates before rasterizing, so it renders cleanly)
