### PR TITLE
docs(constants): render at-a-glance figures for the remaining visual constants

### DIFF
--- a/datachart/constants.py
+++ b/datachart/constants.py
@@ -420,6 +420,8 @@ class HISTOGRAM_TYPE:
 
     Passed as the `plot_hist_type` style attribute of histograms.
 
+    ![HISTOGRAM_TYPE at a glance](../../assets/imgs/const-histogram-type.svg){ width="100%" }
+
     Examples:
         >>> from datachart.constants import HISTOGRAM_TYPE
         >>> HISTOGRAM_TYPE.BAR
@@ -444,6 +446,8 @@ class BAR_MODE:
 
     Passed as the `bar_mode` setting of bar charts and
     [`Panel`][datachart.utils.Panel]: how multiple bar series share the axis.
+
+    ![BAR_MODE at a glance](../../assets/imgs/const-bar-mode.svg){ width="100%" }
 
     Examples:
         >>> from datachart.constants import BAR_MODE
@@ -606,6 +610,8 @@ class NORMALIZE:
     before they are mapped to colors. Distinct from
     [`SCALE`][datachart.constants.SCALE], which sets an axis scale.
 
+    ![NORMALIZE at a glance](../../assets/imgs/const-normalize.svg){ width="100%" }
+
     Examples:
         >>> from datachart.constants import NORMALIZE
         >>> NORMALIZE.LINEAR
@@ -632,6 +638,8 @@ class ORIENTATION:
 
     Passed as the `orientation` setting of bar charts, histograms, and box
     plots.
+
+    ![ORIENTATION at a glance](../../assets/imgs/const-orientation.svg){ width="100%" }
 
     Examples:
         >>> from datachart.constants import ORIENTATION
@@ -722,6 +730,8 @@ class EMPHASIS:
     Set per chart via the `emphasis` key in a charts list, or per figure via
     the `emphasis` argument of [`Panel`][datachart.utils.Panel].
 
+    ![EMPHASIS at a glance](../../assets/imgs/const-emphasis.svg){ width="100%" }
+
     Examples:
         >>> from datachart.constants import EMPHASIS
         >>> EMPHASIS.BACKGROUND
@@ -743,6 +753,11 @@ class EMPHASIS:
 class SHOW_GRID:
     """The supported show grid options.
 
+    Passed as the `show_grid` chart setting: which grid lines to draw. When
+    unset (or `NONE`), the theme's `chart_default_show_grid` fills in.
+
+    ![SHOW_GRID at a glance](../../assets/imgs/const-show-grid.svg){ width="100%" }
+
     Examples:
         >>> from datachart.constants import SHOW_GRID
         >>> SHOW_GRID.DEFAULT
@@ -750,7 +765,7 @@ class SHOW_GRID:
 
     Attributes:
         DEFAULT (str): The default show grid. Same as `SHOW_GRID.NONE`.
-        NONE (None): Do not show the grid. Equals to `None`.
+        NONE (None): No explicit grid; the theme default applies. Equals to `None`.
         X (str): Show the x-axis grid. Equals to `"x"`.
         Y (str): Show the y-axis grid. Equals to `"y"`.
         BOTH (str): Show both the x- and y-axis grid. Equals to `"both"`.
@@ -770,6 +785,8 @@ class SCALE:
     Passed as the `scalex`/`scaley` chart settings to set an axis scale.
     Distinct from [`NORMALIZE`][datachart.constants.NORMALIZE], which
     normalizes heatmap colors.
+
+    ![SCALE at a glance](../../assets/imgs/const-scale.svg){ width="100%" }
 
     Examples:
         >>> from datachart.constants import SCALE
@@ -794,6 +811,11 @@ class SCALE:
 
 class ASPECT_RATIO:
     """The supported aspect ratio options.
+
+    Passed as the `aspect_ratio` chart setting: the ratio of the y-unit to
+    the x-unit on screen.
+
+    ![ASPECT_RATIO at a glance](../../assets/imgs/const-aspect-ratio.svg){ width="100%" }
 
     Examples:
         >>> from datachart.constants import ASPECT_RATIO

--- a/docs/adr/0013-constant-figures-via-chart-fronts.md
+++ b/docs/adr/0013-constant-figures-via-chart-fronts.md
@@ -1,0 +1,36 @@
+---
+status: accepted
+---
+
+# Constant at-a-glance figures render through the chart fronts
+
+The `const-*.svg` at-a-glance figures (ADR 0010's audit left most constants
+without one) are extended to every visually meaningful constants class:
+`BAR_MODE`, `HISTOGRAM_TYPE`, `ORIENTATION`, `SHOW_GRID`, `SCALE`,
+`NORMALIZE`, `EMPHASIS`, `ASPECT_RATIO`. `FIG_FORMAT` (nothing to draw),
+`COLORS` (Colormaps guide) and `THEME` (Theme Gallery) stay figure-less.
+
+Where the constant is a chart or panel *setting*, the figure is produced by
+calling the datachart fronts themselves (`BarChart`, `Histogram`, `Heatmap`,
+`LineChart`, …) and saving the returned figure — not by re-drawing the
+effect with raw matplotlib. Package-specific behavior (`EMPHASIS` muting
+rules, bar slotting, shared bins) is then accurate by construction and
+cannot drift from the implementation; the docs also show real package
+output. Raw matplotlib remains only for constants that are matplotlib
+pass-throughs with no front to exercise (fonts, markers, line styles).
+
+Shared conventions stay: 7 in content width, monospace `CLASS.MEMBER`
+labels, DEFAULT_THEME styling, one generator function per class in
+`docs/assets/scripts/generate_constant_viz.py`. Comparison panels share one
+dataset chosen to be legal for every member (heatmap values in (0, 1) so
+LOGIT works; positive growth data for SCALE), with a footnote where a
+member's distinguishing case (negatives for SYMLOG/ASINH) is not shown.
+
+## Considered options
+
+- **Raw matplotlib for all new figures** (existing script style). Rejected:
+  hand-drawn `EMPHASIS`/`BAR_MODE` panels would silently drift from the
+  package's actual rendering rules.
+- **Per-member tuned datasets in comparison panels.** Rejected: the point
+  of a comparison strip is the same data under different settings; a
+  footnote covers the members whose strengths need different data.

--- a/docs/assets/imgs/const-aspect-ratio.svg
+++ b/docs/assets/imgs/const-aspect-ratio.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="507.97375pt" height="206.257752pt" viewBox="0 0 507.97375 206.257752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="510.186635pt" height="216.481752pt" viewBox="0 0 510.186635 216.481752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:34:26.163846</dc:date>
+    <dc:date>2026-08-23T23:46:43.895988</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,19 +21,19 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 206.257752 
-L 507.97375 206.257752 
-L 507.97375 0 
+   <path d="M 0 216.481752 
+L 510.186635 216.481752 
+L 510.186635 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 27.82024 174.540145 
-L 265.00976 174.540145 
-L 265.00976 20.037891 
-L 27.82024 20.037891 
+    <path d="M 24.82 174.540145 
+L 262.00952 174.540145 
+L 262.00952 20.037891 
+L 24.82 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,17 +41,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m75e8524c2e" d="M 0 0 
+       <path id="m3b399f92ba" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m75e8524c2e" x="37.455045" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="34.454805" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0.00 -->
-      <g transform="translate(29.67067 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(26.67043 187.040145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -92,12 +92,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m75e8524c2e" x="64.674195" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="61.673955" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 0.25 -->
-      <g transform="translate(56.88982 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(53.88958 187.040145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-15" d="M 200 0 
 Q 231 578 439 1006 
@@ -161,12 +161,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m75e8524c2e" x="91.893345" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="88.893105" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 0.50 -->
-      <g transform="translate(84.10897 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(81.10873 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -177,12 +177,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m75e8524c2e" x="119.112495" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="116.112255" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 0.75 -->
-      <g transform="translate(111.32812 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(108.32788 187.040145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-1a" d="M 3347 4400 
 L 3347 3909 
@@ -209,12 +209,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m75e8524c2e" x="146.331645" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="143.331405" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 1.00 -->
-      <g transform="translate(138.54727 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(135.54703 187.040145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -238,12 +238,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m75e8524c2e" x="173.550796" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="170.550556" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 1.25 -->
-      <g transform="translate(165.766421 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(162.766181 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
@@ -254,12 +254,12 @@ z
     <g id="xtick_7">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m75e8524c2e" x="200.769946" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="197.769706" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 1.50 -->
-      <g transform="translate(192.985571 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(189.985331 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -270,12 +270,12 @@ z
     <g id="xtick_8">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m75e8524c2e" x="227.989096" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="224.988856" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 1.75 -->
-      <g transform="translate(220.204721 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(217.204481 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-1a" transform="translate(83.390625 0)"/>
@@ -286,12 +286,12 @@ z
     <g id="xtick_9">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m75e8524c2e" x="255.208246" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="252.208006" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 2.00 -->
-      <g transform="translate(247.423871 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(244.423631 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -303,23 +303,23 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_10">
-      <path d="M 27.82024 168.049679 
-L 265.00976 168.049679 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 168.049679 
+L 262.00952 168.049679 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <defs>
-       <path id="m36e8dd2ef4" d="M 0 0 
+       <path id="m0b254f0ba9" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="168.049679" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="168.049679" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0.0 -->
-      <g transform="translate(10.20024 171.049679) scale(0.08 -0.08)">
+      <g transform="translate(7.2 171.049679) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -328,18 +328,18 @@ L -3 0
     </g>
     <g id="ytick_2">
      <g id="line2d_12">
-      <path d="M 27.82024 150.229325 
-L 265.00976 150.229325 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 150.229325 
+L 262.00952 150.229325 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="150.229325" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="150.229325" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0.5 -->
-      <g transform="translate(10.20024 153.229325) scale(0.08 -0.08)">
+      <g transform="translate(7.2 153.229325) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -348,18 +348,18 @@ L 265.00976 150.229325
     </g>
     <g id="ytick_3">
      <g id="line2d_14">
-      <path d="M 27.82024 132.408971 
-L 265.00976 132.408971 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 132.408971 
+L 262.00952 132.408971 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="132.408971" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="132.408971" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 1.0 -->
-      <g transform="translate(10.20024 135.408971) scale(0.08 -0.08)">
+      <g transform="translate(7.2 135.408971) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -368,18 +368,18 @@ L 265.00976 132.408971
     </g>
     <g id="ytick_4">
      <g id="line2d_16">
-      <path d="M 27.82024 114.588618 
-L 265.00976 114.588618 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 114.588618 
+L 262.00952 114.588618 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="114.588618" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="114.588618" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 1.5 -->
-      <g transform="translate(10.20024 117.588618) scale(0.08 -0.08)">
+      <g transform="translate(7.2 117.588618) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -388,18 +388,18 @@ L 265.00976 114.588618
     </g>
     <g id="ytick_5">
      <g id="line2d_18">
-      <path d="M 27.82024 96.768264 
-L 265.00976 96.768264 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 96.768264 
+L 262.00952 96.768264 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="96.768264" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="96.768264" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 2.0 -->
-      <g transform="translate(10.20024 99.768264) scale(0.08 -0.08)">
+      <g transform="translate(7.2 99.768264) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -408,18 +408,18 @@ L 265.00976 96.768264
     </g>
     <g id="ytick_6">
      <g id="line2d_20">
-      <path d="M 27.82024 78.94791 
-L 265.00976 78.94791 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 78.94791 
+L 262.00952 78.94791 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="78.94791" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="78.94791" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 2.5 -->
-      <g transform="translate(10.20024 81.94791) scale(0.08 -0.08)">
+      <g transform="translate(7.2 81.94791) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -428,18 +428,18 @@ L 265.00976 78.94791
     </g>
     <g id="ytick_7">
      <g id="line2d_22">
-      <path d="M 27.82024 61.127556 
-L 265.00976 61.127556 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 61.127556 
+L 262.00952 61.127556 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="61.127556" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="61.127556" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 3.0 -->
-      <g transform="translate(10.20024 64.127556) scale(0.08 -0.08)">
+      <g transform="translate(7.2 64.127556) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -484,18 +484,18 @@ z
     </g>
     <g id="ytick_8">
      <g id="line2d_24">
-      <path d="M 27.82024 43.307202 
-L 265.00976 43.307202 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 43.307202 
+L 262.00952 43.307202 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="43.307202" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="43.307202" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 3.5 -->
-      <g transform="translate(10.20024 46.307202) scale(0.08 -0.08)">
+      <g transform="translate(7.2 46.307202) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -504,18 +504,18 @@ L 265.00976 43.307202
     </g>
     <g id="ytick_9">
      <g id="line2d_26">
-      <path d="M 27.82024 25.486848 
-L 265.00976 25.486848 
-" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 24.82 25.486848 
+L 262.00952 25.486848 
+" clip-path="url(#p79953f2860)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="25.486848" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="24.82" y="25.486848" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- 4.0 -->
-      <g transform="translate(10.20024 28.486848) scale(0.08 -0.08)">
+      <g transform="translate(7.2 28.486848) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -546,7 +546,7 @@ z
    </g>
    <g id="PathCollection_1">
     <defs>
-     <path id="mdcb09d3037" d="M 0 3 
+     <path id="m52c8cb8706" d="M 0 3 
 C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
 C 2.683901 1.55874 3 0.795609 3 0 
 C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
@@ -558,52 +558,52 @@ C -1.55874 2.683901 -0.795609 3 0 3
 z
 " style="stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
     </defs>
-    <g clip-path="url(#p6356bcf6e3)">
-     <use xlink:href="#mdcb09d3037" x="173.571584" y="40.140339" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="206.363087" y="135.943505" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="102.817214" y="43.513427" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="38.601582" y="50.973031" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="211.019464" y="101.339547" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="103.441326" y="128.356536" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="92.953713" y="104.598341" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="147.322043" y="89.14153" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="254.228418" y="55.045552" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="172.936564" y="27.06072" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="84.339203" y="145.209398" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="170.837504" y="161.785182" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="45.22454" y="94.645671" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="138.972899" y="37.295645" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="174.471076" y="94.755612" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="145.650826" y="132.763251" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="40.023232" y="140.620285" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="188.147254" y="139.450617" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="117.922759" y="167.517315" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="218.200595" y="146.02927" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="95.72565" y="42.547035" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="148.463626" y="47.277541" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="176.755506" y="62.300713" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="57.378506" y="90.902684" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="148.024075" y="43.829071" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="116.12145" y="82.770865" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="50.35728" y="112.787792" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="107.797243" y="146.636781" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="215.21528" y="113.954759" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="250.58053" y="83.938793" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="169.207981" y="77.09508" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="184.754251" y="146.552912" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="133.334712" y="133.896763" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="125.100338" y="154.26327" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="248.202701" y="137.398095" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="183.734059" y="125.220942" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="227.788115" y="73.642471" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="66.11481" y="47.573491" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="243.220534" y="39.184743" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="161.513213" y="147.312496" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+    <g clip-path="url(#p79953f2860)">
+     <use xlink:href="#m52c8cb8706" x="170.571344" y="40.140339" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="203.362847" y="135.943505" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="99.816974" y="43.513427" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="35.601342" y="50.973031" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="208.019224" y="101.339547" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="100.441086" y="128.356536" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="89.953473" y="104.598341" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="144.321803" y="89.14153" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="251.228178" y="55.045552" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="169.936324" y="27.06072" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="81.338963" y="145.209398" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="167.837264" y="161.785182" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="42.2243" y="94.645671" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="135.972659" y="37.295645" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="171.470836" y="94.755612" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="142.650586" y="132.763251" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="37.022992" y="140.620285" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="185.147014" y="139.450617" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="114.922519" y="167.517315" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="215.200355" y="146.02927" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="92.72541" y="42.547035" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="145.463386" y="47.277541" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="173.755266" y="62.300713" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="54.378266" y="90.902684" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="145.023835" y="43.829071" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="113.12121" y="82.770865" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="47.35704" y="112.787792" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="104.797003" y="146.636781" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="212.21504" y="113.954759" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="247.58029" y="83.938793" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="166.207741" y="77.09508" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="181.754011" y="146.552912" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="130.334472" y="133.896763" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="122.100098" y="154.26327" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="245.202461" y="137.398095" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="180.733819" y="125.220942" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="224.787875" y="73.642471" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="63.11457" y="47.573491" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="240.220294" y="39.184743" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="158.512973" y="147.312496" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
     </g>
    </g>
    <g id="text_19">
     <!-- ASPECT_RATIO.AUTO -->
-    <g transform="translate(100.359609 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(97.359369 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-24" d="M 1925 4109 
 L 1259 1722 
@@ -844,22 +844,22 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 27.82024 174.540145 
-L 27.82024 20.037891 
+    <path d="M 24.82 174.540145 
+L 24.82 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 27.82024 174.540145 
-L 265.00976 174.540145 
+    <path d="M 24.82 174.540145 
+L 262.00952 174.540145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_5">
-    <path d="M 350.783057 174.540145 
-L 428.426943 174.540145 
-L 428.426943 20.037891 
-L 350.783057 20.037891 
+    <path d="M 347.782817 174.540145 
+L 425.426703 174.540145 
+L 425.426703 20.037891 
+L 347.782817 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -867,12 +867,12 @@ z
     <g id="xtick_10">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m75e8524c2e" x="353.937006" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="350.936766" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- 0 -->
-      <g transform="translate(351.712631 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(348.712391 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -880,12 +880,12 @@ z
     <g id="xtick_11">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m75e8524c2e" x="389.577714" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="386.577474" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 1 -->
-      <g transform="translate(387.353339 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(384.353099 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -893,12 +893,12 @@ z
     <g id="xtick_12">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m75e8524c2e" x="425.218422" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m3b399f92ba" x="422.218182" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 2 -->
-      <g transform="translate(422.994047 187.040145) scale(0.08 -0.08)">
+      <g transform="translate(419.993807 187.040145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -907,18 +907,18 @@ z
    <g id="matplotlib.axis_4">
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 350.783057 168.049679 
-L 428.426943 168.049679 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 168.049679 
+L 425.426703 168.049679 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="168.049679" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="168.049679" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 0.0 -->
-      <g transform="translate(333.163057 171.049679) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 171.049679) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -927,18 +927,18 @@ L 428.426943 168.049679
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 350.783057 150.229325 
-L 428.426943 150.229325 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 150.229325 
+L 425.426703 150.229325 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="150.229325" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="150.229325" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 0.5 -->
-      <g transform="translate(333.163057 153.229325) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 153.229325) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -947,18 +947,18 @@ L 428.426943 150.229325
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 350.783057 132.408971 
-L 428.426943 132.408971 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 132.408971 
+L 425.426703 132.408971 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="132.408971" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="132.408971" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
       <!-- 1.0 -->
-      <g transform="translate(333.163057 135.408971) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 135.408971) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -967,18 +967,18 @@ L 428.426943 132.408971
     </g>
     <g id="ytick_13">
      <g id="line2d_37">
-      <path d="M 350.783057 114.588618 
-L 428.426943 114.588618 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 114.588618 
+L 425.426703 114.588618 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="114.588618" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="114.588618" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
       <!-- 1.5 -->
-      <g transform="translate(333.163057 117.588618) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 117.588618) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -987,18 +987,18 @@ L 428.426943 114.588618
     </g>
     <g id="ytick_14">
      <g id="line2d_39">
-      <path d="M 350.783057 96.768264 
-L 428.426943 96.768264 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 96.768264 
+L 425.426703 96.768264 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="96.768264" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="96.768264" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
       <!-- 2.0 -->
-      <g transform="translate(333.163057 99.768264) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 99.768264) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1007,18 +1007,18 @@ L 428.426943 96.768264
     </g>
     <g id="ytick_15">
      <g id="line2d_41">
-      <path d="M 350.783057 78.94791 
-L 428.426943 78.94791 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 78.94791 
+L 425.426703 78.94791 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="78.94791" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="78.94791" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_28">
       <!-- 2.5 -->
-      <g transform="translate(333.163057 81.94791) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 81.94791) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -1027,18 +1027,18 @@ L 428.426943 78.94791
     </g>
     <g id="ytick_16">
      <g id="line2d_43">
-      <path d="M 350.783057 61.127556 
-L 428.426943 61.127556 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 61.127556 
+L 425.426703 61.127556 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="61.127556" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="61.127556" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_29">
       <!-- 3.0 -->
-      <g transform="translate(333.163057 64.127556) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 64.127556) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1047,18 +1047,18 @@ L 428.426943 61.127556
     </g>
     <g id="ytick_17">
      <g id="line2d_45">
-      <path d="M 350.783057 43.307202 
-L 428.426943 43.307202 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 43.307202 
+L 425.426703 43.307202 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="43.307202" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="43.307202" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_30">
       <!-- 3.5 -->
-      <g transform="translate(333.163057 46.307202) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 46.307202) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
@@ -1067,18 +1067,18 @@ L 428.426943 43.307202
     </g>
     <g id="ytick_18">
      <g id="line2d_47">
-      <path d="M 350.783057 25.486848 
-L 428.426943 25.486848 
-" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 347.782817 25.486848 
+L 425.426703 25.486848 
+" clip-path="url(#p62cb9aa706)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="25.486848" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m0b254f0ba9" x="347.782817" y="25.486848" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
       <!-- 4.0 -->
-      <g transform="translate(333.163057 28.486848) scale(0.08 -0.08)">
+      <g transform="translate(330.162817 28.486848) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
@@ -1087,52 +1087,52 @@ L 428.426943 25.486848
     </g>
    </g>
    <g id="PathCollection_2">
-    <g clip-path="url(#pb2ead50b2e)">
-     <use xlink:href="#mdcb09d3037" x="398.494696" y="40.140339" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="409.22898" y="135.943505" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="375.333284" y="43.513427" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="354.312324" y="50.973031" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="410.753243" y="101.339547" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="375.537586" y="128.356536" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="372.104471" y="104.598341" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="389.90192" y="89.14153" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="424.897676" y="55.045552" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="398.286822" y="27.06072" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="369.284515" y="145.209398" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="397.599696" y="161.785182" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="356.480347" y="94.645671" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="387.168832" y="37.295645" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="398.789144" y="94.755612" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="389.354848" y="132.763251" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="354.777701" y="140.620285" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="403.266035" y="139.450617" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="380.278077" y="167.517315" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="413.103983" y="146.02927" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="373.011863" y="42.547035" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="390.275617" y="47.277541" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="399.536951" y="62.300713" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="360.458942" y="90.902684" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="390.13173" y="43.829071" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="379.68842" y="82.770865" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="358.160547" y="112.787792" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="376.963494" y="146.636781" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="412.126742" y="113.954759" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="423.703541" y="83.938793" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="397.066272" y="77.09508" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="402.155337" y="146.552912" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="385.323173" y="133.896763" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="382.627655" y="154.26327" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="422.92516" y="137.398095" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="401.821378" y="125.220942" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="416.242454" y="73.642471" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="363.318768" y="47.573491" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="421.29425" y="39.184743" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
-     <use xlink:href="#mdcb09d3037" x="394.547393" y="147.312496" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+    <g clip-path="url(#p62cb9aa706)">
+     <use xlink:href="#m52c8cb8706" x="395.494456" y="40.140339" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="406.22874" y="135.943505" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="372.333044" y="43.513427" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="351.312084" y="50.973031" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="407.753003" y="101.339547" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="372.537346" y="128.356536" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="369.104231" y="104.598341" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="386.90168" y="89.14153" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="421.897436" y="55.045552" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="395.286582" y="27.06072" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="366.284275" y="145.209398" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="394.599456" y="161.785182" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="353.480107" y="94.645671" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="384.168592" y="37.295645" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="395.788904" y="94.755612" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="386.354608" y="132.763251" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="351.777461" y="140.620285" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="400.265795" y="139.450617" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="377.277837" y="167.517315" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="410.103743" y="146.02927" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="370.011623" y="42.547035" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="387.275377" y="47.277541" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="396.536711" y="62.300713" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="357.458702" y="90.902684" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="387.13149" y="43.829071" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="376.68818" y="82.770865" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="355.160307" y="112.787792" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="373.963254" y="146.636781" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="409.126502" y="113.954759" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="420.703301" y="83.938793" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="394.066032" y="77.09508" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="399.155097" y="146.552912" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="382.322933" y="133.896763" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="379.627415" y="154.26327" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="419.92492" y="137.398095" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="398.821138" y="125.220942" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="413.242214" y="73.642471" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="360.318528" y="47.573491" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="418.29401" y="39.184743" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#m52c8cb8706" x="391.547153" y="147.312496" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
     </g>
    </g>
    <g id="text_32">
     <!-- ASPECT_RATIO.EQUAL -->
-    <g transform="translate(340.840469 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(337.840229 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-34" d="M 2047 -84 
 Q 2025 -84 1984 -87 
@@ -1191,19 +1191,19 @@ z
     </g>
    </g>
    <g id="patch_6">
-    <path d="M 350.783057 174.540145 
-L 350.783057 20.037891 
+    <path d="M 347.782817 174.540145 
+L 347.782817 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 350.783057 174.540145 
-L 428.426943 174.540145 
+    <path d="M 347.782817 174.540145 
+L 425.426703 174.540145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_33">
    <!-- The y range is twice the x range; AUTO stretches the data to fill the box, EQUAL keeps one unit equal on both axes. -->
-   <g transform="translate(7.2 197.01576) scale(0.085 -0.085)">
+   <g transform="translate(9.412885 207.23976) scale(0.085 -0.085)">
     <defs>
      <path id="DejaVuSans-Oblique-37" d="M 378 4666 
 L 4325 4666 
@@ -2027,11 +2027,11 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p6356bcf6e3">
-   <rect x="27.82024" y="20.037891" width="237.18952" height="154.502254"/>
+  <clipPath id="p79953f2860">
+   <rect x="24.82" y="20.037891" width="237.18952" height="154.502254"/>
   </clipPath>
-  <clipPath id="pb2ead50b2e">
-   <rect x="350.783057" y="20.037891" width="77.643886" height="154.502254"/>
+  <clipPath id="p62cb9aa706">
+   <rect x="347.782817" y="20.037891" width="77.643886" height="154.502254"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/imgs/const-aspect-ratio.svg
+++ b/docs/assets/imgs/const-aspect-ratio.svg
@@ -1,0 +1,2037 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="507.97375pt" height="206.257752pt" viewBox="0 0 507.97375 206.257752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:26.163846</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 206.257752 
+L 507.97375 206.257752 
+L 507.97375 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 27.82024 174.540145 
+L 265.00976 174.540145 
+L 265.00976 20.037891 
+L 27.82024 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m75e8524c2e" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m75e8524c2e" x="37.455045" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0.00 -->
+      <g transform="translate(29.67067 187.040145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-11" d="M 547 681 
+L 1200 681 
+L 1200 0 
+L 547 0 
+L 547 681 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="64.674195" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 0.25 -->
+      <g transform="translate(56.88982 187.040145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="91.893345" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0.50 -->
+      <g transform="translate(84.10897 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="119.112495" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0.75 -->
+      <g transform="translate(111.32812 187.040145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-1a" d="M 3347 4400 
+L 3347 3909 
+Q 3131 3700 2773 3181 
+Q 2416 2663 2141 2063 
+Q 1869 1478 1728 997 
+Q 1638 688 1494 0 
+L 872 0 
+Q 1084 1281 1809 2550 
+Q 2238 3294 2709 3834 
+L 234 3834 
+L 234 4400 
+L 3347 4400 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-1a" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="146.331645" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 1.00 -->
+      <g transform="translate(138.54727 187.040145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="173.550796" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1.25 -->
+      <g transform="translate(165.766421 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-15" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="200.769946" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 1.50 -->
+      <g transform="translate(192.985571 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="227.989096" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 1.75 -->
+      <g transform="translate(220.204721 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-1a" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="255.208246" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2.00 -->
+      <g transform="translate(247.423871 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(139 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 27.82024 168.049679 
+L 265.00976 168.049679 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <defs>
+       <path id="m36e8dd2ef4" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="168.049679" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0.0 -->
+      <g transform="translate(10.20024 171.049679) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 27.82024 150.229325 
+L 265.00976 150.229325 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="150.229325" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0.5 -->
+      <g transform="translate(10.20024 153.229325) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 27.82024 132.408971 
+L 265.00976 132.408971 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="132.408971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 1.0 -->
+      <g transform="translate(10.20024 135.408971) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 27.82024 114.588618 
+L 265.00976 114.588618 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="114.588618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 1.5 -->
+      <g transform="translate(10.20024 117.588618) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 27.82024 96.768264 
+L 265.00976 96.768264 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="96.768264" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 2.0 -->
+      <g transform="translate(10.20024 99.768264) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 27.82024 78.94791 
+L 265.00976 78.94791 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="78.94791" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2.5 -->
+      <g transform="translate(10.20024 81.94791) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 27.82024 61.127556 
+L 265.00976 61.127556 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="61.127556" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 3.0 -->
+      <g transform="translate(10.20024 64.127556) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 27.82024 43.307202 
+L 265.00976 43.307202 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="43.307202" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 3.5 -->
+      <g transform="translate(10.20024 46.307202) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_26">
+      <path d="M 27.82024 25.486848 
+L 265.00976 25.486848 
+" clip-path="url(#p6356bcf6e3)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="27.82024" y="25.486848" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 4.0 -->
+      <g transform="translate(10.20024 28.486848) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="PathCollection_1">
+    <defs>
+     <path id="mdcb09d3037" d="M 0 3 
+C 0.795609 3 1.55874 2.683901 2.12132 2.12132 
+C 2.683901 1.55874 3 0.795609 3 0 
+C 3 -0.795609 2.683901 -1.55874 2.12132 -2.12132 
+C 1.55874 -2.683901 0.795609 -3 0 -3 
+C -0.795609 -3 -1.55874 -2.683901 -2.12132 -2.12132 
+C -2.683901 -1.55874 -3 -0.795609 -3 0 
+C -3 0.795609 -2.683901 1.55874 -2.12132 2.12132 
+C -1.55874 2.683901 -0.795609 3 0 3 
+z
+" style="stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+    </defs>
+    <g clip-path="url(#p6356bcf6e3)">
+     <use xlink:href="#mdcb09d3037" x="173.571584" y="40.140339" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="206.363087" y="135.943505" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="102.817214" y="43.513427" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="38.601582" y="50.973031" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="211.019464" y="101.339547" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="103.441326" y="128.356536" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="92.953713" y="104.598341" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="147.322043" y="89.14153" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="254.228418" y="55.045552" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="172.936564" y="27.06072" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="84.339203" y="145.209398" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="170.837504" y="161.785182" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="45.22454" y="94.645671" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="138.972899" y="37.295645" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="174.471076" y="94.755612" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="145.650826" y="132.763251" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="40.023232" y="140.620285" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="188.147254" y="139.450617" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="117.922759" y="167.517315" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="218.200595" y="146.02927" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="95.72565" y="42.547035" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="148.463626" y="47.277541" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="176.755506" y="62.300713" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="57.378506" y="90.902684" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="148.024075" y="43.829071" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="116.12145" y="82.770865" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="50.35728" y="112.787792" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="107.797243" y="146.636781" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="215.21528" y="113.954759" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="250.58053" y="83.938793" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="169.207981" y="77.09508" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="184.754251" y="146.552912" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="133.334712" y="133.896763" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="125.100338" y="154.26327" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="248.202701" y="137.398095" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="183.734059" y="125.220942" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="227.788115" y="73.642471" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="66.11481" y="47.573491" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="243.220534" y="39.184743" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="161.513213" y="147.312496" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- ASPECT_RATIO.AUTO -->
+    <g transform="translate(100.359609 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-33" d="M 1247 4147 
+L 1247 2394 
+L 1978 2394 
+Q 2416 2394 2661 2625 
+Q 2906 2856 2906 3272 
+Q 2906 3688 2662 3917 
+Q 2419 4147 1978 4147 
+L 1247 4147 
+z
+M 616 4666 
+L 1978 4666 
+Q 2759 4666 3162 4311 
+Q 3566 3956 3566 3272 
+Q 3566 2581 3164 2228 
+Q 2763 1875 1978 1875 
+L 1247 1875 
+L 1247 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-26" d="M 3353 166 
+Q 3113 38 2859 -26 
+Q 2606 -91 2322 -91 
+Q 1425 -91 929 543 
+Q 434 1178 434 2328 
+Q 434 3472 932 4111 
+Q 1431 4750 2322 4750 
+Q 2606 4750 2859 4686 
+Q 3113 4622 3353 4494 
+L 3353 3847 
+Q 3122 4038 2856 4138 
+Q 2591 4238 2322 4238 
+Q 1706 4238 1400 3763 
+Q 1094 3288 1094 2328 
+Q 1094 1372 1400 897 
+Q 1706 422 2322 422 
+Q 2597 422 2861 522 
+Q 3125 622 3353 813 
+L 3353 166 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-42" d="M 3853 -1259 
+L 3853 -1509 
+L 0 -1509 
+L 0 -1259 
+L 3853 -1259 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-38" d="M 459 1791 
+L 459 4666 
+L 1094 4666 
+L 1094 1503 
+Q 1094 1163 1112 1017 
+Q 1131 872 1178 794 
+Q 1278 609 1467 515 
+Q 1656 422 1925 422 
+Q 2197 422 2384 515 
+Q 2572 609 2675 794 
+Q 2722 872 2740 1015 
+Q 2759 1159 2759 1497 
+L 2759 4666 
+L 3391 4666 
+L 3391 1791 
+Q 3391 1075 3302 773 
+Q 3213 472 2994 275 
+Q 2788 91 2522 0 
+Q 2256 -91 1925 -91 
+Q 1597 -91 1331 0 
+Q 1066 91 856 275 
+Q 641 469 550 776 
+Q 459 1084 459 1791 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-24"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-38" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(963.25 0)"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 27.82024 174.540145 
+L 27.82024 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 27.82024 174.540145 
+L 265.00976 174.540145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 350.783057 174.540145 
+L 428.426943 174.540145 
+L 428.426943 20.037891 
+L 350.783057 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_10">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="353.937006" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(351.712631 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="389.577714" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 1 -->
+      <g transform="translate(387.353339 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m75e8524c2e" x="425.218422" y="174.540145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 2 -->
+      <g transform="translate(422.994047 187.040145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <path d="M 350.783057 168.049679 
+L 428.426943 168.049679 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="168.049679" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 0.0 -->
+      <g transform="translate(333.163057 171.049679) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_33">
+      <path d="M 350.783057 150.229325 
+L 428.426943 150.229325 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="150.229325" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 0.5 -->
+      <g transform="translate(333.163057 153.229325) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_35">
+      <path d="M 350.783057 132.408971 
+L 428.426943 132.408971 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="132.408971" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 1.0 -->
+      <g transform="translate(333.163057 135.408971) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_37">
+      <path d="M 350.783057 114.588618 
+L 428.426943 114.588618 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="114.588618" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 1.5 -->
+      <g transform="translate(333.163057 117.588618) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_39">
+      <path d="M 350.783057 96.768264 
+L 428.426943 96.768264 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="96.768264" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 2.0 -->
+      <g transform="translate(333.163057 99.768264) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 350.783057 78.94791 
+L 428.426943 78.94791 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="78.94791" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 2.5 -->
+      <g transform="translate(333.163057 81.94791) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 350.783057 61.127556 
+L 428.426943 61.127556 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="61.127556" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 3.0 -->
+      <g transform="translate(333.163057 64.127556) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 350.783057 43.307202 
+L 428.426943 43.307202 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="43.307202" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 3.5 -->
+      <g transform="translate(333.163057 46.307202) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_47">
+      <path d="M 350.783057 25.486848 
+L 428.426943 25.486848 
+" clip-path="url(#pb2ead50b2e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m36e8dd2ef4" x="350.783057" y="25.486848" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 4.0 -->
+      <g transform="translate(333.163057 28.486848) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-11" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(83.390625 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="PathCollection_2">
+    <g clip-path="url(#pb2ead50b2e)">
+     <use xlink:href="#mdcb09d3037" x="398.494696" y="40.140339" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="409.22898" y="135.943505" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="375.333284" y="43.513427" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="354.312324" y="50.973031" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="410.753243" y="101.339547" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="375.537586" y="128.356536" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="372.104471" y="104.598341" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="389.90192" y="89.14153" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="424.897676" y="55.045552" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="398.286822" y="27.06072" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="369.284515" y="145.209398" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="397.599696" y="161.785182" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="356.480347" y="94.645671" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="387.168832" y="37.295645" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="398.789144" y="94.755612" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="389.354848" y="132.763251" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="354.777701" y="140.620285" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="403.266035" y="139.450617" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="380.278077" y="167.517315" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="413.103983" y="146.02927" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="373.011863" y="42.547035" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="390.275617" y="47.277541" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="399.536951" y="62.300713" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="360.458942" y="90.902684" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="390.13173" y="43.829071" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="379.68842" y="82.770865" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="358.160547" y="112.787792" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="376.963494" y="146.636781" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="412.126742" y="113.954759" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="423.703541" y="83.938793" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="397.066272" y="77.09508" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="402.155337" y="146.552912" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="385.323173" y="133.896763" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="382.627655" y="154.26327" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="422.92516" y="137.398095" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="401.821378" y="125.220942" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="416.242454" y="73.642471" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="363.318768" y="47.573491" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="421.29425" y="39.184743" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+     <use xlink:href="#mdcb09d3037" x="394.547393" y="147.312496" style="fill: #4e79a7; fill-opacity: 0.75; stroke: #ffffff; stroke-opacity: 0.75; stroke-width: 0.5"/>
+    </g>
+   </g>
+   <g id="text_32">
+    <!-- ASPECT_RATIO.EQUAL -->
+    <g transform="translate(340.840469 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-34" d="M 2047 -84 
+Q 2025 -84 1984 -87 
+Q 1944 -91 1919 -91 
+Q 1138 -91 752 509 
+Q 366 1109 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+Q 3488 1409 3273 848 
+Q 3059 288 2625 63 
+L 3250 -531 
+L 2778 -844 
+L 2047 -84 
+z
+M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-24"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-34" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-38" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(1023.453125 0)"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 350.783057 174.540145 
+L 350.783057 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 350.783057 174.540145 
+L 428.426943 174.540145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_33">
+   <!-- The y range is twice the x range; AUTO stretches the data to fill the box, EQUAL keeps one unit equal on both axes. -->
+   <g transform="translate(7.2 197.01576) scale(0.085 -0.085)">
+    <defs>
+     <path id="DejaVuSans-Oblique-37" d="M 378 4666 
+L 4325 4666 
+L 4225 4134 
+L 2559 4134 
+L 1759 0 
+L 1125 0 
+L 1925 4134 
+L 275 4134 
+L 378 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5c" d="M 1588 -325 
+Q 1188 -997 936 -1164 
+Q 684 -1331 294 -1331 
+L -159 -1331 
+L -63 -850 
+L 269 -850 
+Q 509 -850 678 -719 
+Q 847 -588 1056 -206 
+L 1234 128 
+L 459 3500 
+L 1069 3500 
+L 1650 819 
+L 3256 3500 
+L 3859 3500 
+L 1588 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5a" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5b" d="M 3841 3500 
+L 2234 1784 
+L 3219 0 
+L 2559 0 
+L 1819 1388 
+L 531 0 
+L -166 0 
+L 1556 1844 
+L 641 3500 
+L 1300 3500 
+L 1972 2234 
+L 3144 3500 
+L 3841 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-24" d="M 2356 4666 
+L 3072 4666 
+L 3938 0 
+L 3278 0 
+L 3084 1197 
+L 984 1197 
+L 325 0 
+L -341 0 
+L 2356 4666 
+z
+M 2584 4044 
+L 1275 1722 
+L 2988 1722 
+L 2584 4044 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-38" d="M 991 4666 
+L 1625 4666 
+L 1075 1831 
+Q 1041 1641 1027 1517 
+Q 1013 1394 1013 1300 
+Q 1013 869 1253 645 
+Q 1494 422 1959 422 
+Q 2563 422 2898 753 
+Q 3234 1084 3378 1831 
+L 3928 4666 
+L 4563 4666 
+L 4000 1753 
+Q 3816 809 3300 359 
+Q 2784 -91 1888 -91 
+Q 1188 -91 780 261 
+Q 372 613 372 1216 
+Q 372 1325 387 1461 
+Q 403 1597 434 1753 
+L 991 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-32" d="M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+M 2100 -91 
+Q 1241 -91 748 418 
+Q 256 928 256 1813 
+Q 256 2319 448 2847 
+Q 641 3375 978 3788 
+Q 1375 4272 1862 4511 
+Q 2350 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 2331 4593 1812 
+Q 4406 1294 4056 872 
+Q 3656 384 3173 146 
+Q 2691 -91 2100 -91 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-127c" d="M 3525 4863 
+L 4103 4863 
+L 3963 4134 
+L 3384 4134 
+L 3525 4863 
+z
+M 3059 4863 
+L 2969 4384 
+L 2419 4384 
+Q 2106 4384 1964 4261 
+Q 1822 4138 1753 3809 
+L 1691 3500 
+L 3841 3500 
+L 3156 0 
+L 2578 0 
+L 3188 3056 
+L 1606 3056 
+L 1013 0 
+L 434 0 
+L 1031 3053 
+L 481 3053 
+L 563 3500 
+L 1113 3500 
+L 1159 3744 
+Q 1278 4363 1575 4613 
+Q 1875 4863 2516 4863 
+L 3059 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-45" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-f" d="M 575 794 
+L 1234 794 
+L 1131 256 
+L 422 -744 
+L 19 -744 
+L 469 256 
+L 575 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-28" d="M 1081 4666 
+L 4031 4666 
+L 3928 4134 
+L 1606 4134 
+L 1338 2753 
+L 3566 2753 
+L 3463 2222 
+L 1234 2222 
+L 909 531 
+L 3284 531 
+L 3181 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-34" d="M 2309 -84 
+Q 2275 -88 2237 -89 
+Q 2200 -91 2125 -91 
+Q 1250 -91 756 411 
+Q 263 913 263 1797 
+Q 263 2319 452 2844 
+Q 641 3369 978 3788 
+Q 1369 4269 1858 4509 
+Q 2347 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 1928 4265 1147 
+Q 3750 366 2919 44 
+L 3553 -825 
+L 2847 -825 
+L 2309 -84 
+z
+M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2f" d="M 1075 4666 
+L 1709 4666 
+L 909 525 
+L 3181 525 
+L 3078 0 
+L 172 0 
+L 1075 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4e" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-58" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-54" d="M 2669 525 
+Q 2438 222 2123 65 
+Q 1809 -91 1428 -91 
+Q 897 -91 595 267 
+Q 294 625 294 1253 
+Q 294 1759 480 2231 
+Q 666 2703 1013 3078 
+Q 1238 3322 1530 3453 
+Q 1822 3584 2144 3584 
+Q 2531 3584 2781 3431 
+Q 3031 3278 3144 2969 
+L 3244 3494 
+L 3822 3494 
+L 2888 -1319 
+L 2309 -1319 
+L 2669 525 
+z
+M 891 1338 
+Q 891 875 1084 633 
+Q 1278 391 1644 391 
+Q 2188 391 2572 911 
+Q 2956 1431 2956 2175 
+Q 2956 2625 2757 2864 
+Q 2559 3103 2188 3103 
+Q 1916 3103 1684 2976 
+Q 1453 2850 1281 2606 
+Q 1100 2350 995 2006 
+Q 891 1663 891 1338 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-11" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-37"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(61.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(124.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(185.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(217.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(276.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(308.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(349.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(411.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(474.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(537.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(599.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(631.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(659.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(711.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(742.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(782.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(863.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(891.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(946.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1008.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(1040.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1079.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1142.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1204.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5b" transform="translate(1235.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1295.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1326.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1367.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(1429.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(1492.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1556.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(1617.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1651.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(1683.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(1751.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-37" transform="translate(1824.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-32" transform="translate(1885.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1964.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1996.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2048.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2087.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2128.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2190.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(2229.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(2284.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2347.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2409.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2461.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2493.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(2532.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2595.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2657.3125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(2689.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2752.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2813.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2853.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2914.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2946.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(2985.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3046.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-127c" transform="translate(3078.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(3142.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(3170.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3198.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3230.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3269.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3332.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3394.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-45" transform="translate(3426.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3489.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5b" transform="translate(3550.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-f" transform="translate(3609.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3641.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(3673.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-34" transform="translate(3736.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(3815.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(3888.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(3957.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4012.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4e" transform="translate(4044.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4102.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4163.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(4225.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(4289 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4341.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4372.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(4434.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4497.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4558.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(4590.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(4654.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(4717.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(4745.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4784.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4816.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-54" transform="translate(4877.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(4941.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(5004.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(5065.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5093.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(5125.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(5186.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5250.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-45" transform="translate(5281.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(5345.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(5406.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5445.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5509.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(5540.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5b" transform="translate(5602.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5661.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(5722.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(5774.96875 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6356bcf6e3">
+   <rect x="27.82024" y="20.037891" width="237.18952" height="154.502254"/>
+  </clipPath>
+  <clipPath id="pb2ead50b2e">
+   <rect x="350.783057" y="20.037891" width="77.643886" height="154.502254"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-bar-mode.svg
+++ b/docs/assets/imgs/const-bar-mode.svg
@@ -1,0 +1,1636 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="166.79952pt" viewBox="0 0 512.39952 166.79952" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:25.455953</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 166.79952 
+L 512.39952 166.79952 
+L 512.39952 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 18.14875 145.38452 
+L 167.716603 145.38452 
+L 167.716603 20.037891 
+L 18.14875 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m5fbd2fbeed" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="39.260002" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- w -->
+      <g transform="translate(36.371252 157.88452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5a" d="M 672 3347 
+L 1316 709 
+L 1969 3347 
+L 2600 3347 
+L 3256 725 
+L 3941 3347 
+L 4503 3347 
+L 3531 0 
+L 2947 0 
+L 2266 2591 
+L 1606 0 
+L 1022 0 
+L 56 3347 
+L 672 3347 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5a"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="75.041785" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- x -->
+      <g transform="translate(73.041785 157.88452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5b" d="M 94 3347 
+L 822 3347 
+L 1591 2169 
+L 2369 3347 
+L 3053 3331 
+L 1925 1716 
+L 3103 0 
+L 2384 0 
+L 1553 1256 
+L 747 0 
+L 34 0 
+L 1213 1716 
+L 94 3347 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="110.823568" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- y -->
+      <g transform="translate(108.823568 157.88452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5c" d="M 2503 3347 
+L 3125 3347 
+Q 3006 3025 2597 1878 
+Q 2291 1016 2084 472 
+Q 1597 -809 1397 -1090 
+Q 1197 -1372 709 -1372 
+Q 591 -1372 527 -1362 
+Q 463 -1353 369 -1328 
+L 369 -816 
+Q 516 -856 581 -865 
+Q 647 -875 697 -875 
+Q 853 -875 926 -823 
+Q 1000 -772 1050 -697 
+Q 1066 -672 1162 -440 
+Q 1259 -209 1303 -97 
+L 66 3347 
+L 703 3347 
+L 1600 622 
+L 2503 3347 
+z
+M 1597 3428 
+L 1597 3428 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5c"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="146.605351" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- z -->
+      <g transform="translate(144.605351 157.88452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5d" d="M 163 444 
+L 2147 2844 
+L 309 2844 
+L 309 3347 
+L 2903 3347 
+L 2903 2888 
+L 931 503 
+L 2963 503 
+L 2963 0 
+L 163 0 
+L 163 444 
+z
+M 1609 3428 
+L 1609 3428 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5d"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 18.14875 145.38452 
+L 167.716603 145.38452 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m8ce2840883" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(7.2 148.38452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 18.14875 125.48823 
+L 167.716603 125.48823 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="125.48823" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1 -->
+      <g transform="translate(7.2 128.48823) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 18.14875 105.591939 
+L 167.716603 105.591939 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="105.591939" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 2 -->
+      <g transform="translate(7.2 108.591939) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 18.14875 85.695649 
+L 167.716603 85.695649 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="85.695649" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 3 -->
+      <g transform="translate(7.2 88.695649) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 18.14875 65.799358 
+L 167.716603 65.799358 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="65.799358" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 4 -->
+      <g transform="translate(7.2 68.799358) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 18.14875 45.903068 
+L 167.716603 45.903068 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="45.903068" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 5 -->
+      <g transform="translate(7.2 48.903068) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <path d="M 18.14875 26.006778 
+L 167.716603 26.006778 
+" clip-path="url(#p70526bc161)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m8ce2840883" x="18.14875" y="26.006778" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(7.2 29.006778) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 24.947289 145.38452 
+L 34.489098 145.38452 
+L 34.489098 65.799358 
+L 24.947289 65.799358 
+z
+" clip-path="url(#p70526bc161)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 60.729072 145.38452 
+L 70.270881 145.38452 
+L 70.270881 26.006778 
+L 60.729072 26.006778 
+z
+" clip-path="url(#p70526bc161)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 96.510855 145.38452 
+L 106.052664 145.38452 
+L 106.052664 85.695649 
+L 96.510855 85.695649 
+z
+" clip-path="url(#p70526bc161)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 132.292638 145.38452 
+L 141.834447 145.38452 
+L 141.834447 45.903068 
+L 132.292638 45.903068 
+z
+" clip-path="url(#p70526bc161)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 34.489098 145.38452 
+L 44.030906 145.38452 
+L 44.030906 105.591939 
+L 34.489098 105.591939 
+z
+" clip-path="url(#p70526bc161)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 70.270881 145.38452 
+L 79.81269 145.38452 
+L 79.81269 85.695649 
+L 70.270881 85.695649 
+z
+" clip-path="url(#p70526bc161)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 106.052664 145.38452 
+L 115.594473 145.38452 
+L 115.594473 45.903068 
+L 106.052664 45.903068 
+z
+" clip-path="url(#p70526bc161)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 141.834447 145.38452 
+L 151.376256 145.38452 
+L 151.376256 105.591939 
+L 141.834447 105.591939 
+z
+" clip-path="url(#p70526bc161)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 44.030906 145.38452 
+L 53.572715 145.38452 
+L 53.572715 85.695649 
+L 44.030906 85.695649 
+z
+" clip-path="url(#p70526bc161)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 79.81269 145.38452 
+L 89.354498 145.38452 
+L 89.354498 125.48823 
+L 79.81269 125.48823 
+z
+" clip-path="url(#p70526bc161)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 115.594473 145.38452 
+L 125.136281 145.38452 
+L 125.136281 105.591939 
+L 115.594473 105.591939 
+z
+" clip-path="url(#p70526bc161)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 151.376256 145.38452 
+L 160.918065 145.38452 
+L 160.918065 65.799358 
+L 151.376256 65.799358 
+z
+" clip-path="url(#p70526bc161)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_12">
+    <!-- BAR_MODE.GROUP -->
+    <g transform="translate(55.004708 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-25" d="M 1153 2228 
+L 1153 519 
+L 1900 519 
+Q 2450 519 2684 711 
+Q 2919 903 2919 1344 
+Q 2919 1800 2672 2014 
+Q 2425 2228 1900 2228 
+L 1153 2228 
+z
+M 1153 4147 
+L 1153 2741 
+L 1888 2741 
+Q 2344 2741 2548 2916 
+Q 2753 3091 2753 3481 
+Q 2753 3834 2551 3990 
+Q 2350 4147 1888 4147 
+L 1153 4147 
+z
+M 519 4666 
+L 1900 4666 
+Q 2616 4666 3003 4356 
+Q 3391 4047 3391 3481 
+Q 3391 3053 3186 2806 
+Q 2981 2559 2572 2497 
+Q 3031 2428 3292 2104 
+Q 3553 1781 3553 1281 
+Q 3553 647 3137 323 
+Q 2722 0 1900 0 
+L 519 0 
+L 519 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-42" d="M 3853 -1259 
+L 3853 -1509 
+L 0 -1509 
+L 0 -1259 
+L 3853 -1259 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-30" d="M 269 4666 
+L 1113 4666 
+L 1919 2291 
+L 2731 4666 
+L 3578 4666 
+L 3578 0 
+L 2994 0 
+L 2994 4122 
+L 2163 1663 
+L 1684 1663 
+L 850 4122 
+L 850 0 
+L 269 0 
+L 269 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-27" d="M 1363 519 
+Q 2159 519 2475 911 
+Q 2791 1303 2791 2328 
+Q 2791 3363 2477 3755 
+Q 2163 4147 1363 4147 
+L 1063 4147 
+L 1063 519 
+L 1363 519 
+z
+M 1375 4666 
+Q 2444 4666 2950 4097 
+Q 3456 3528 3456 2328 
+Q 3456 1134 2950 567 
+Q 2444 0 1375 0 
+L 428 0 
+L 428 4666 
+L 1375 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2a" d="M 3450 384 
+Q 3197 150 2880 29 
+Q 2563 -91 2194 -91 
+Q 1306 -91 812 545 
+Q 319 1181 319 2328 
+Q 319 3472 819 4111 
+Q 1319 4750 2209 4750 
+Q 2503 4750 2772 4667 
+Q 3041 4584 3291 4416 
+L 3291 3769 
+Q 3038 4009 2772 4123 
+Q 2506 4238 2209 4238 
+Q 1594 4238 1286 3761 
+Q 978 3284 978 2328 
+Q 978 1356 1276 889 
+Q 1575 422 2194 422 
+Q 2403 422 2561 470 
+Q 2719 519 2847 622 
+L 2847 1875 
+L 2169 1875 
+L 2169 2394 
+L 3450 2394 
+L 3450 384 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-38" d="M 459 1791 
+L 459 4666 
+L 1094 4666 
+L 1094 1503 
+Q 1094 1163 1112 1017 
+Q 1131 872 1178 794 
+Q 1278 609 1467 515 
+Q 1656 422 1925 422 
+Q 2197 422 2384 515 
+Q 2572 609 2675 794 
+Q 2722 872 2740 1015 
+Q 2759 1159 2759 1497 
+L 2759 4666 
+L 3391 4666 
+L 3391 1791 
+Q 3391 1075 3302 773 
+Q 3213 472 2994 275 
+Q 2788 91 2522 0 
+Q 2256 -91 1925 -91 
+Q 1597 -91 1331 0 
+Q 1066 91 856 275 
+Q 641 469 550 776 
+Q 459 1084 459 1791 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-33" d="M 1247 4147 
+L 1247 2394 
+L 1978 2394 
+Q 2416 2394 2661 2625 
+Q 2906 2856 2906 3272 
+Q 2906 3688 2662 3917 
+Q 2419 4147 1978 4147 
+L 1247 4147 
+z
+M 616 4666 
+L 1978 4666 
+Q 2759 4666 3162 4311 
+Q 3566 3956 3566 3272 
+Q 3566 2581 3164 2228 
+Q 2763 1875 1978 1875 
+L 1247 1875 
+L 1247 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-25"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-38" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(782.640625 0)"/>
+    </g>
+   </g>
+   <g id="patch_15">
+    <path d="M 18.14875 145.38452 
+L 18.14875 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 18.14875 145.38452 
+L 167.716603 145.38452 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_17">
+    <path d="M 189.114583 145.38452 
+L 338.682437 145.38452 
+L 338.682437 20.037891 
+L 189.114583 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="210.225835" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- w -->
+      <g transform="translate(207.337085 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5a"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="246.007618" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- x -->
+      <g transform="translate(244.007618 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="281.789402" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- y -->
+      <g transform="translate(279.789402 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5c"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="317.571185" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- z -->
+      <g transform="translate(315.571185 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5d"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_23">
+      <path d="M 189.114583 145.38452 
+L 338.682437 145.38452 
+" clip-path="url(#p7d7d05afb0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m8ce2840883" x="189.114583" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0 -->
+      <g transform="translate(178.165833 148.38452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_25">
+      <path d="M 189.114583 123.679476 
+L 338.682437 123.679476 
+" clip-path="url(#p7d7d05afb0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m8ce2840883" x="189.114583" y="123.679476" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 2 -->
+      <g transform="translate(178.165833 126.679476) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_27">
+      <path d="M 189.114583 101.974432 
+L 338.682437 101.974432 
+" clip-path="url(#p7d7d05afb0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m8ce2840883" x="189.114583" y="101.974432" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 4 -->
+      <g transform="translate(178.165833 104.974432) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_29">
+      <path d="M 189.114583 80.269388 
+L 338.682437 80.269388 
+" clip-path="url(#p7d7d05afb0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m8ce2840883" x="189.114583" y="80.269388" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 6 -->
+      <g transform="translate(178.165833 83.269388) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_31">
+      <path d="M 189.114583 58.564344 
+L 338.682437 58.564344 
+" clip-path="url(#p7d7d05afb0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m8ce2840883" x="189.114583" y="58.564344" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 8 -->
+      <g transform="translate(178.165833 61.564344) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-1b" d="M 1741 2600 
+Q 2113 2600 2322 2808 
+Q 2531 3016 2531 3303 
+Q 2531 3553 2331 3762 
+Q 2131 3972 1722 3972 
+Q 1316 3972 1134 3762 
+Q 953 3553 953 3272 
+Q 953 2956 1187 2778 
+Q 1422 2600 1741 2600 
+z
+M 1775 384 
+Q 2166 384 2423 595 
+Q 2681 806 2681 1225 
+Q 2681 1659 2415 1884 
+Q 2150 2109 1734 2109 
+Q 1331 2109 1076 1879 
+Q 822 1650 822 1244 
+Q 822 894 1055 639 
+Q 1288 384 1775 384 
+z
+M 975 2384 
+Q 741 2484 609 2619 
+Q 363 2869 363 3269 
+Q 363 3769 725 4128 
+Q 1088 4488 1753 4488 
+Q 2397 4488 2762 4148 
+Q 3128 3809 3128 3356 
+Q 3128 2938 2916 2678 
+Q 2797 2531 2547 2391 
+Q 2825 2263 2984 2097 
+Q 3281 1784 3281 1284 
+Q 3281 694 2884 283 
+Q 2488 -128 1763 -128 
+Q 1109 -128 657 226 
+Q 206 581 206 1256 
+Q 206 1653 400 1942 
+Q 594 2231 975 2384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-1b"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_33">
+      <path d="M 189.114583 36.8593 
+L 338.682437 36.8593 
+" clip-path="url(#p7d7d05afb0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m8ce2840883" x="189.114583" y="36.8593" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 10 -->
+      <g transform="translate(173.717083 39.8593) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_18">
+    <path d="M 195.913122 145.38452 
+L 224.538549 145.38452 
+L 224.538549 101.974432 
+L 195.913122 101.974432 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 231.694905 145.38452 
+L 260.320332 145.38452 
+L 260.320332 80.269388 
+L 231.694905 80.269388 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 267.476688 145.38452 
+L 296.102115 145.38452 
+L 296.102115 112.826954 
+L 267.476688 112.826954 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 303.258471 145.38452 
+L 331.883898 145.38452 
+L 331.883898 91.12191 
+L 303.258471 91.12191 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 195.913122 101.974432 
+L 224.538549 101.974432 
+L 224.538549 80.269388 
+L 195.913122 80.269388 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 231.694905 80.269388 
+L 260.320332 80.269388 
+L 260.320332 47.711822 
+L 231.694905 47.711822 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 267.476688 112.826954 
+L 296.102115 112.826954 
+L 296.102115 58.564344 
+L 267.476688 58.564344 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 303.258471 91.12191 
+L 331.883898 91.12191 
+L 331.883898 69.416866 
+L 303.258471 69.416866 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 195.913122 80.269388 
+L 224.538549 80.269388 
+L 224.538549 47.711822 
+L 195.913122 47.711822 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 231.694905 47.711822 
+L 260.320332 47.711822 
+L 260.320332 36.8593 
+L 231.694905 36.8593 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 267.476688 58.564344 
+L 296.102115 58.564344 
+L 296.102115 36.8593 
+L 267.476688 36.8593 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 303.258471 69.416866 
+L 331.883898 69.416866 
+L 331.883898 26.006778 
+L 303.258471 26.006778 
+z
+" clip-path="url(#p7d7d05afb0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_23">
+    <!-- BAR_MODE.STACK -->
+    <g transform="translate(225.970541 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-26" d="M 3353 166 
+Q 3113 38 2859 -26 
+Q 2606 -91 2322 -91 
+Q 1425 -91 929 543 
+Q 434 1178 434 2328 
+Q 434 3472 932 4111 
+Q 1431 4750 2322 4750 
+Q 2606 4750 2859 4686 
+Q 3113 4622 3353 4494 
+L 3353 3847 
+Q 3122 4038 2856 4138 
+Q 2591 4238 2322 4238 
+Q 1706 4238 1400 3763 
+Q 1094 3288 1094 2328 
+Q 1094 1372 1400 897 
+Q 1706 422 2322 422 
+Q 2597 422 2861 522 
+Q 3125 622 3353 813 
+L 3353 166 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2e" d="M 428 4666 
+L 1063 4666 
+L 1063 2591 
+L 3034 4666 
+L 3775 4666 
+L 1959 2759 
+L 3828 0 
+L 3066 0 
+L 1544 2338 
+L 1063 1825 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-25"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2e" transform="translate(782.640625 0)"/>
+    </g>
+   </g>
+   <g id="patch_30">
+    <path d="M 189.114583 145.38452 
+L 189.114583 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 189.114583 145.38452 
+L 338.682437 145.38452 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_32">
+    <path d="M 355.631667 145.38452 
+L 505.19952 145.38452 
+L 505.19952 20.037891 
+L 355.631667 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_9">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="376.742919" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- w -->
+      <g transform="translate(373.854169 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5a"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="412.524702" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- x -->
+      <g transform="translate(410.524702 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="448.306485" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- y -->
+      <g transform="translate(446.306485 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5c"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m5fbd2fbeed" x="484.088268" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- z -->
+      <g transform="translate(482.088268 157.88452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5d"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_14">
+     <g id="line2d_39">
+      <path d="M 355.631667 145.38452 
+L 505.19952 145.38452 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="145.38452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 0 -->
+      <g transform="translate(344.682917 148.38452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_41">
+      <path d="M 355.631667 125.48823 
+L 505.19952 125.48823 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="125.48823" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 1 -->
+      <g transform="translate(344.682917 128.48823) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_43">
+      <path d="M 355.631667 105.591939 
+L 505.19952 105.591939 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="105.591939" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 2 -->
+      <g transform="translate(344.682917 108.591939) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_45">
+      <path d="M 355.631667 85.695649 
+L 505.19952 85.695649 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="85.695649" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 3 -->
+      <g transform="translate(344.682917 88.695649) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_47">
+      <path d="M 355.631667 65.799358 
+L 505.19952 65.799358 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="65.799358" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 4 -->
+      <g transform="translate(344.682917 68.799358) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_49">
+      <path d="M 355.631667 45.903068 
+L 505.19952 45.903068 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="45.903068" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 5 -->
+      <g transform="translate(344.682917 48.903068) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_51">
+      <path d="M 355.631667 26.006778 
+L 505.19952 26.006778 
+" clip-path="url(#p41fd481cf0)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m8ce2840883" x="355.631667" y="26.006778" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 6 -->
+      <g transform="translate(344.682917 29.006778) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_33">
+    <path d="M 362.430205 145.38452 
+L 391.055632 145.38452 
+L 391.055632 65.799358 
+L 362.430205 65.799358 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 398.211989 145.38452 
+L 426.837415 145.38452 
+L 426.837415 26.006778 
+L 398.211989 26.006778 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 433.993772 145.38452 
+L 462.619198 145.38452 
+L 462.619198 85.695649 
+L 433.993772 85.695649 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 469.775555 145.38452 
+L 498.400981 145.38452 
+L 498.400981 45.903068 
+L 469.775555 45.903068 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 362.430205 145.38452 
+L 391.055632 145.38452 
+L 391.055632 105.591939 
+L 362.430205 105.591939 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 398.211989 145.38452 
+L 426.837415 145.38452 
+L 426.837415 85.695649 
+L 398.211989 85.695649 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 433.993772 145.38452 
+L 462.619198 145.38452 
+L 462.619198 45.903068 
+L 433.993772 45.903068 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 469.775555 145.38452 
+L 498.400981 145.38452 
+L 498.400981 105.591939 
+L 469.775555 105.591939 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 362.430205 145.38452 
+L 391.055632 145.38452 
+L 391.055632 85.695649 
+L 362.430205 85.695649 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 398.211989 145.38452 
+L 426.837415 145.38452 
+L 426.837415 125.48823 
+L 398.211989 125.48823 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 433.993772 145.38452 
+L 462.619198 145.38452 
+L 462.619198 105.591939 
+L 433.993772 105.591939 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 469.775555 145.38452 
+L 498.400981 145.38452 
+L 498.400981 65.799358 
+L 469.775555 65.799358 
+z
+" clip-path="url(#p41fd481cf0)" style="fill: #59a14f; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_35">
+    <!-- BAR_MODE.OVERLAY -->
+    <g transform="translate(387.069343 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-39" d="M 1925 531 
+L 3022 4666 
+L 3675 4666 
+L 2309 0 
+L 1544 0 
+L 178 4666 
+L 831 4666 
+L 1925 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-3c" d="M 116 4666 
+L 788 4666 
+L 1925 2606 
+L 3059 4666 
+L 3738 4666 
+L 2241 2094 
+L 2241 0 
+L 1606 0 
+L 1606 2094 
+L 116 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-25"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-39" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(903.046875 0)"/>
+    </g>
+   </g>
+   <g id="patch_45">
+    <path d="M 355.631667 145.38452 
+L 355.631667 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 355.631667 145.38452 
+L 505.19952 145.38452 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p70526bc161">
+   <rect x="18.14875" y="20.037891" width="149.567853" height="125.346629"/>
+  </clipPath>
+  <clipPath id="p7d7d05afb0">
+   <rect x="189.114583" y="20.037891" width="149.567853" height="125.346629"/>
+  </clipPath>
+  <clipPath id="p41fd481cf0">
+   <rect x="355.631667" y="20.037891" width="149.567853" height="125.346629"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-emphasis.svg
+++ b/docs/assets/imgs/const-emphasis.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="191.425752pt" viewBox="0 0 515.39976 191.425752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="202.081752pt" viewBox="0 0 512.39952 202.081752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:34:26.103345</dc:date>
+    <dc:date>2026-08-23T23:46:43.831834</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,19 +21,19 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 191.425752 
-L 515.39976 191.425752 
-L 515.39976 0 
-L 0 0 
+   <path d="M 0 202.081752 
+L 512.39952 202.081752 
+L 512.39952 -0 
+L 0 -0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 21.14899 160.140145 
-L 253.975385 160.140145 
-L 253.975385 20.037891 
-L 21.14899 20.037891 
+    <path d="M 18.14875 160.140145 
+L 250.975145 160.140145 
+L 250.975145 20.037891 
+L 18.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,17 +41,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m40c17b1354" d="M 0 0 
+       <path id="mc64aaa31a8" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m40c17b1354" x="21.14899" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="18.14875" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0 -->
-      <g transform="translate(18.924615 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(15.924375 172.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -82,12 +82,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m40c17b1354" x="67.714269" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="64.714029" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 1 -->
-      <g transform="translate(65.489894 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(62.489654 172.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -108,12 +108,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m40c17b1354" x="114.279548" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="111.279308" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 2 -->
-      <g transform="translate(112.055173 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(109.054933 172.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-15" d="M 200 0 
 Q 231 578 439 1006 
@@ -148,12 +148,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m40c17b1354" x="160.844827" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="157.844587" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 3 -->
-      <g transform="translate(158.620452 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(155.620212 172.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -197,12 +197,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m40c17b1354" x="207.410106" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="204.409866" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 4 -->
-      <g transform="translate(205.185731 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(202.185491 172.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -231,12 +231,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m40c17b1354" x="253.975385" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="250.975145" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 5 -->
-      <g transform="translate(251.75101 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(248.75077 172.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-18" d="M 791 1141 
 Q 847 659 1238 475 
@@ -273,59 +273,59 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 21.14899 137.85115 
-L 253.975385 137.85115 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 18.14875 137.85115 
+L 250.975145 137.85115 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m2aeb96f9fe" d="M 0 0 
+       <path id="m48be00e3b4" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="137.85115" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="18.14875" y="137.85115" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 2 -->
-      <g transform="translate(10.20024 140.85115) scale(0.08 -0.08)">
+      <g transform="translate(7.2 140.85115) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 21.14899 106.009729 
-L 253.975385 106.009729 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 18.14875 106.009729 
+L 250.975145 106.009729 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="106.009729" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="18.14875" y="106.009729" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 4 -->
-      <g transform="translate(10.20024 109.009729) scale(0.08 -0.08)">
+      <g transform="translate(7.2 109.009729) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 21.14899 74.168307 
-L 253.975385 74.168307 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 18.14875 74.168307 
+L 250.975145 74.168307 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="74.168307" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="18.14875" y="74.168307" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 6 -->
-      <g transform="translate(10.20024 77.168307) scale(0.08 -0.08)">
+      <g transform="translate(7.2 77.168307) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-19" d="M 1872 4494 
 Q 2622 4494 2917 4105 
@@ -364,18 +364,18 @@ z
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 21.14899 42.326886 
-L 253.975385 42.326886 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 18.14875 42.326886 
+L 250.975145 42.326886 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="42.326886" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="18.14875" y="42.326886" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 8 -->
-      <g transform="translate(10.20024 45.326886) scale(0.08 -0.08)">
+      <g transform="translate(7.2 45.326886) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-1b" d="M 1741 2600 
 Q 2113 2600 2322 2808 
@@ -423,35 +423,35 @@ z
     </g>
    </g>
    <g id="line2d_15">
-    <path d="M 21.14899 129.890795 
-L 67.714269 98.049373 
-L 114.279548 113.970084 
-L 160.844827 66.207952 
-L 207.410106 82.128662 
-L 253.975385 50.287241 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #cfcfcf; stroke-opacity: 0.5; stroke-width: 1.125; stroke-linecap: square"/>
+    <path d="M 18.14875 129.890795 
+L 64.714029 98.049373 
+L 111.279308 113.970084 
+L 157.844587 66.207952 
+L 204.409866 82.128662 
+L 250.975145 50.287241 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #cfcfcf; stroke-opacity: 0.5; stroke-width: 1.125; stroke-linecap: square"/>
    </g>
    <g id="line2d_16">
-    <path d="M 21.14899 153.771861 
-L 67.714269 121.930439 
-L 114.279548 137.85115 
-L 160.844827 90.089018 
-L 207.410106 106.009729 
-L 253.975385 74.168307 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 18.14875 153.771861 
+L 64.714029 121.930439 
+L 111.279308 137.85115 
+L 157.844587 90.089018 
+L 204.409866 106.009729 
+L 250.975145 74.168307 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_17">
-    <path d="M 21.14899 106.009729 
-L 67.714269 74.168307 
-L 114.279548 90.089018 
-L 160.844827 42.326886 
-L 207.410106 58.247596 
-L 253.975385 26.406175 
-" clip-path="url(#p2716e163de)" style="fill: none; stroke: #f28e2b; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 18.14875 106.009729 
+L 64.714029 74.168307 
+L 111.279308 90.089018 
+L 157.844587 42.326886 
+L 204.409866 58.247596 
+L 250.975145 26.406175 
+" clip-path="url(#p478fe71f7b)" style="fill: none; stroke: #f28e2b; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_11">
     <!-- EMPHASIS.BACKGROUND -->
-    <g transform="translate(86.088516 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(83.088276 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-28" d="M 616 4666 
 L 3384 4666 
@@ -812,21 +812,21 @@ z
    </g>
    <g id="legend_1">
     <g id="patch_3">
-     <path d="M 26.74899 62.616641 
-L 79.02274 62.616641 
-Q 80.62274 62.616641 80.62274 61.016641 
-L 80.62274 25.637891 
-Q 80.62274 24.037891 79.02274 24.037891 
-L 26.74899 24.037891 
-Q 25.14899 24.037891 25.14899 25.637891 
-L 25.14899 61.016641 
-Q 25.14899 62.616641 26.74899 62.616641 
+     <path d="M 23.74875 62.616641 
+L 76.0225 62.616641 
+Q 77.6225 62.616641 77.6225 61.016641 
+L 77.6225 25.637891 
+Q 77.6225 24.037891 76.0225 24.037891 
+L 23.74875 24.037891 
+Q 22.14875 24.037891 22.14875 25.637891 
+L 22.14875 61.016641 
+Q 22.14875 62.616641 23.74875 62.616641 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="text_12">
      <!-- Legend -->
-     <g transform="translate(28.34899 33.987891) scale(0.09 -0.09)">
+     <g transform="translate(25.34875 33.987891) scale(0.09 -0.09)">
       <defs>
        <path id="Helvetica-2f" d="M 488 4591 
 L 1109 4591 
@@ -964,14 +964,14 @@ z
      </g>
     </g>
     <g id="line2d_18">
-     <path d="M 28.34899 43.179141 
-L 36.34899 43.179141 
-L 44.34899 43.179141 
+     <path d="M 25.34875 43.179141 
+L 33.34875 43.179141 
+L 41.34875 43.179141 
 " style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_13">
      <!-- alpha -->
-     <g transform="translate(50.74899 45.979141) scale(0.08 -0.08)">
+     <g transform="translate(47.74875 45.979141) scale(0.08 -0.08)">
       <defs>
        <path id="Helvetica-44" d="M 844 891 
 Q 844 647 1022 506 
@@ -1080,14 +1080,14 @@ z
      </g>
     </g>
     <g id="line2d_19">
-     <path d="M 28.34899 54.846641 
-L 36.34899 54.846641 
-L 44.34899 54.846641 
+     <path d="M 25.34875 54.846641 
+L 33.34875 54.846641 
+L 41.34875 54.846641 
 " style="fill: none; stroke: #f28e2b; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_14">
      <!-- gamma -->
-     <g transform="translate(50.74899 57.646641) scale(0.08 -0.08)">
+     <g transform="translate(47.74875 57.646641) scale(0.08 -0.08)">
       <defs>
        <path id="Helvetica-50" d="M 413 3347 
 L 969 3347 
@@ -1129,22 +1129,22 @@ z
     </g>
    </g>
    <g id="patch_4">
-    <path d="M 21.14899 160.140145 
-L 21.14899 20.037891 
+    <path d="M 18.14875 160.140145 
+L 18.14875 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 21.14899 160.140145 
-L 253.975385 160.140145 
+    <path d="M 18.14875 160.140145 
+L 250.975145 160.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_6">
-    <path d="M 273.14899 160.140145 
-L 505.975385 160.140145 
-L 505.975385 20.037891 
-L 273.14899 20.037891 
+    <path d="M 270.14875 160.140145 
+L 502.975145 160.140145 
+L 502.975145 20.037891 
+L 270.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -1152,12 +1152,12 @@ z
     <g id="xtick_7">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m40c17b1354" x="273.14899" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="270.14875" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0 -->
-      <g transform="translate(270.924615 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(267.924375 172.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -1165,12 +1165,12 @@ z
     <g id="xtick_8">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m40c17b1354" x="319.714269" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="316.714029" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 1 -->
-      <g transform="translate(317.489894 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(314.489654 172.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -1178,12 +1178,12 @@ z
     <g id="xtick_9">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m40c17b1354" x="366.279548" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="363.279308" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 2 -->
-      <g transform="translate(364.055173 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(361.054933 172.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -1191,12 +1191,12 @@ z
     <g id="xtick_10">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m40c17b1354" x="412.844827" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="409.844587" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- 3 -->
-      <g transform="translate(410.620452 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(407.620212 172.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -1204,12 +1204,12 @@ z
     <g id="xtick_11">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m40c17b1354" x="459.410106" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="456.409866" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
       <!-- 4 -->
-      <g transform="translate(457.185731 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(454.185491 172.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -1217,12 +1217,12 @@ z
     <g id="xtick_12">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m40c17b1354" x="505.975385" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc64aaa31a8" x="502.975145" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- 5 -->
-      <g transform="translate(503.75101 172.640145) scale(0.08 -0.08)">
+      <g transform="translate(500.75077 172.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
       </g>
      </g>
@@ -1231,98 +1231,98 @@ z
    <g id="matplotlib.axis_4">
     <g id="ytick_5">
      <g id="line2d_26">
-      <path d="M 273.14899 137.85115 
-L 505.975385 137.85115 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 270.14875 137.85115 
+L 502.975145 137.85115 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="137.85115" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="270.14875" y="137.85115" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 2 -->
-      <g transform="translate(262.20024 140.85115) scale(0.08 -0.08)">
+      <g transform="translate(259.2 140.85115) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
     </g>
     <g id="ytick_6">
      <g id="line2d_28">
-      <path d="M 273.14899 106.009729 
-L 505.975385 106.009729 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 270.14875 106.009729 
+L 502.975145 106.009729 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="106.009729" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="270.14875" y="106.009729" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 4 -->
-      <g transform="translate(262.20024 109.009729) scale(0.08 -0.08)">
+      <g transform="translate(259.2 109.009729) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
     </g>
     <g id="ytick_7">
      <g id="line2d_30">
-      <path d="M 273.14899 74.168307 
-L 505.975385 74.168307 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 270.14875 74.168307 
+L 502.975145 74.168307 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="74.168307" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="270.14875" y="74.168307" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 6 -->
-      <g transform="translate(262.20024 77.168307) scale(0.08 -0.08)">
+      <g transform="translate(259.2 77.168307) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-19"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_32">
-      <path d="M 273.14899 42.326886 
-L 505.975385 42.326886 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 270.14875 42.326886 
+L 502.975145 42.326886 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="42.326886" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m48be00e3b4" x="270.14875" y="42.326886" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 8 -->
-      <g transform="translate(262.20024 45.326886) scale(0.08 -0.08)">
+      <g transform="translate(259.2 45.326886) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-1b"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_34">
-    <path d="M 273.14899 153.771861 
-L 319.714269 121.930439 
-L 366.279548 137.85115 
-L 412.844827 90.089018 
-L 459.410106 106.009729 
-L 505.975385 74.168307 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 270.14875 153.771861 
+L 316.714029 121.930439 
+L 363.279308 137.85115 
+L 409.844587 90.089018 
+L 456.409866 106.009729 
+L 502.975145 74.168307 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="line2d_35">
-    <path d="M 273.14899 106.009729 
-L 319.714269 74.168307 
-L 366.279548 90.089018 
-L 412.844827 42.326886 
-L 459.410106 58.247596 
-L 505.975385 26.406175 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #59a14f; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 270.14875 106.009729 
+L 316.714029 74.168307 
+L 363.279308 90.089018 
+L 409.844587 42.326886 
+L 456.409866 58.247596 
+L 502.975145 26.406175 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #59a14f; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_25">
     <!-- EMPHASIS.HIGHLIGHT -->
-    <g transform="translate(340.797656 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(337.797416 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-2f" d="M 672 4666 
 L 1306 4666 
@@ -1366,31 +1366,31 @@ z
     </g>
    </g>
    <g id="line2d_36">
-    <path d="M 273.14899 129.890795 
-L 319.714269 98.049373 
-L 366.279548 113.970084 
-L 412.844827 66.207952 
-L 459.410106 82.128662 
-L 505.975385 50.287241 
-" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #f28e2b; stroke-width: 3; stroke-linecap: square"/>
+    <path d="M 270.14875 129.890795 
+L 316.714029 98.049373 
+L 363.279308 113.970084 
+L 409.844587 66.207952 
+L 456.409866 82.128662 
+L 502.975145 50.287241 
+" clip-path="url(#p8047416d51)" style="fill: none; stroke: #f28e2b; stroke-width: 3; stroke-linecap: square"/>
    </g>
    <g id="legend_2">
     <g id="patch_7">
-     <path d="M 278.74899 73.976016 
-L 331.02274 73.976016 
-Q 332.62274 73.976016 332.62274 72.376016 
-L 332.62274 25.637891 
-Q 332.62274 24.037891 331.02274 24.037891 
-L 278.74899 24.037891 
-Q 277.14899 24.037891 277.14899 25.637891 
-L 277.14899 72.376016 
-Q 277.14899 73.976016 278.74899 73.976016 
+     <path d="M 275.74875 73.976016 
+L 328.0225 73.976016 
+Q 329.6225 73.976016 329.6225 72.376016 
+L 329.6225 25.637891 
+Q 329.6225 24.037891 328.0225 24.037891 
+L 275.74875 24.037891 
+Q 274.14875 24.037891 274.14875 25.637891 
+L 274.14875 72.376016 
+Q 274.14875 73.976016 275.74875 73.976016 
 z
 " style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
     </g>
     <g id="text_26">
      <!-- Legend -->
-     <g transform="translate(280.34899 33.987891) scale(0.09 -0.09)">
+     <g transform="translate(277.34875 33.987891) scale(0.09 -0.09)">
       <use xlink:href="#Helvetica-2f"/>
       <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
       <use xlink:href="#Helvetica-4a" transform="translate(111.21875 0)"/>
@@ -1400,14 +1400,14 @@ z
      </g>
     </g>
     <g id="line2d_37">
-     <path d="M 280.34899 43.179141 
-L 288.34899 43.179141 
-L 296.34899 43.179141 
+     <path d="M 277.34875 43.179141 
+L 285.34875 43.179141 
+L 293.34875 43.179141 
 " style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_27">
      <!-- alpha -->
-     <g transform="translate(302.74899 45.979141) scale(0.08 -0.08)">
+     <g transform="translate(299.74875 45.979141) scale(0.08 -0.08)">
       <use xlink:href="#Helvetica-44"/>
       <use xlink:href="#Helvetica-4f" transform="translate(55.609375 0)"/>
       <use xlink:href="#Helvetica-53" transform="translate(77.828125 0)"/>
@@ -1416,14 +1416,14 @@ L 296.34899 43.179141
      </g>
     </g>
     <g id="line2d_38">
-     <path d="M 280.34899 54.846641 
-L 288.34899 54.846641 
-L 296.34899 54.846641 
+     <path d="M 277.34875 54.846641 
+L 285.34875 54.846641 
+L 293.34875 54.846641 
 " style="fill: none; stroke: #f28e2b; stroke-width: 3; stroke-linecap: square"/>
     </g>
     <g id="text_28">
      <!-- beta -->
-     <g transform="translate(302.74899 57.646641) scale(0.08 -0.08)">
+     <g transform="translate(299.74875 57.646641) scale(0.08 -0.08)">
       <defs>
        <path id="Helvetica-45" d="M 369 4606 
 L 916 4606 
@@ -1482,14 +1482,14 @@ z
      </g>
     </g>
     <g id="line2d_39">
-     <path d="M 280.34899 66.206016 
-L 288.34899 66.206016 
-L 296.34899 66.206016 
+     <path d="M 277.34875 66.206016 
+L 285.34875 66.206016 
+L 293.34875 66.206016 
 " style="fill: none; stroke: #59a14f; stroke-width: 1.5; stroke-linecap: square"/>
     </g>
     <g id="text_29">
      <!-- gamma -->
-     <g transform="translate(302.74899 69.006016) scale(0.08 -0.08)">
+     <g transform="translate(299.74875 69.006016) scale(0.08 -0.08)">
       <use xlink:href="#Helvetica-4a"/>
       <use xlink:href="#Helvetica-44" transform="translate(55.609375 0)"/>
       <use xlink:href="#Helvetica-50" transform="translate(111.21875 0)"/>
@@ -1499,19 +1499,19 @@ L 296.34899 66.206016
     </g>
    </g>
    <g id="patch_8">
-    <path d="M 273.14899 160.140145 
-L 273.14899 20.037891 
+    <path d="M 270.14875 160.140145 
+L 270.14875 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_9">
-    <path d="M 273.14899 160.140145 
-L 505.975385 160.140145 
+    <path d="M 270.14875 160.140145 
+L 502.975145 160.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_30">
    <!-- The "beta" series carries the emphasis role; BACKGROUND also drops its legend entry. -->
-   <g transform="translate(7.2 182.18376) scale(0.085 -0.085)">
+   <g transform="translate(71.543901 192.83976) scale(0.085 -0.085)">
     <defs>
      <path id="DejaVuSans-Oblique-37" d="M 378 4666 
 L 4325 4666 
@@ -2324,11 +2324,11 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p2716e163de">
-   <rect x="21.14899" y="20.037891" width="232.826395" height="140.102254"/>
+  <clipPath id="p478fe71f7b">
+   <rect x="18.14875" y="20.037891" width="232.826395" height="140.102254"/>
   </clipPath>
-  <clipPath id="p12ebfd7627">
-   <rect x="273.14899" y="20.037891" width="232.826395" height="140.102254"/>
+  <clipPath id="p8047416d51">
+   <rect x="270.14875" y="20.037891" width="232.826395" height="140.102254"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/imgs/const-emphasis.svg
+++ b/docs/assets/imgs/const-emphasis.svg
@@ -1,0 +1,2334 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="191.425752pt" viewBox="0 0 515.39976 191.425752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:26.103345</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 191.425752 
+L 515.39976 191.425752 
+L 515.39976 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 21.14899 160.140145 
+L 253.975385 160.140145 
+L 253.975385 20.037891 
+L 21.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m40c17b1354" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m40c17b1354" x="21.14899" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(18.924615 172.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m40c17b1354" x="67.714269" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 1 -->
+      <g transform="translate(65.489894 172.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m40c17b1354" x="114.279548" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 2 -->
+      <g transform="translate(112.055173 172.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m40c17b1354" x="160.844827" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 3 -->
+      <g transform="translate(158.620452 172.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m40c17b1354" x="207.410106" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 4 -->
+      <g transform="translate(205.185731 172.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m40c17b1354" x="253.975385" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 5 -->
+      <g transform="translate(251.75101 172.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <path d="M 21.14899 137.85115 
+L 253.975385 137.85115 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <defs>
+       <path id="m2aeb96f9fe" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="137.85115" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 2 -->
+      <g transform="translate(10.20024 140.85115) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <path d="M 21.14899 106.009729 
+L 253.975385 106.009729 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="106.009729" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 4 -->
+      <g transform="translate(10.20024 109.009729) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_11">
+      <path d="M 21.14899 74.168307 
+L 253.975385 74.168307 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="74.168307" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 6 -->
+      <g transform="translate(10.20024 77.168307) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <path d="M 21.14899 42.326886 
+L 253.975385 42.326886 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="21.14899" y="42.326886" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 8 -->
+      <g transform="translate(10.20024 45.326886) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-1b" d="M 1741 2600 
+Q 2113 2600 2322 2808 
+Q 2531 3016 2531 3303 
+Q 2531 3553 2331 3762 
+Q 2131 3972 1722 3972 
+Q 1316 3972 1134 3762 
+Q 953 3553 953 3272 
+Q 953 2956 1187 2778 
+Q 1422 2600 1741 2600 
+z
+M 1775 384 
+Q 2166 384 2423 595 
+Q 2681 806 2681 1225 
+Q 2681 1659 2415 1884 
+Q 2150 2109 1734 2109 
+Q 1331 2109 1076 1879 
+Q 822 1650 822 1244 
+Q 822 894 1055 639 
+Q 1288 384 1775 384 
+z
+M 975 2384 
+Q 741 2484 609 2619 
+Q 363 2869 363 3269 
+Q 363 3769 725 4128 
+Q 1088 4488 1753 4488 
+Q 2397 4488 2762 4148 
+Q 3128 3809 3128 3356 
+Q 3128 2938 2916 2678 
+Q 2797 2531 2547 2391 
+Q 2825 2263 2984 2097 
+Q 3281 1784 3281 1284 
+Q 3281 694 2884 283 
+Q 2488 -128 1763 -128 
+Q 1109 -128 657 226 
+Q 206 581 206 1256 
+Q 206 1653 400 1942 
+Q 594 2231 975 2384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-1b"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_15">
+    <path d="M 21.14899 129.890795 
+L 67.714269 98.049373 
+L 114.279548 113.970084 
+L 160.844827 66.207952 
+L 207.410106 82.128662 
+L 253.975385 50.287241 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #cfcfcf; stroke-opacity: 0.5; stroke-width: 1.125; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_16">
+    <path d="M 21.14899 153.771861 
+L 67.714269 121.930439 
+L 114.279548 137.85115 
+L 160.844827 90.089018 
+L 207.410106 106.009729 
+L 253.975385 74.168307 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_17">
+    <path d="M 21.14899 106.009729 
+L 67.714269 74.168307 
+L 114.279548 90.089018 
+L 160.844827 42.326886 
+L 207.410106 58.247596 
+L 253.975385 26.406175 
+" clip-path="url(#p2716e163de)" style="fill: none; stroke: #f28e2b; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_11">
+    <!-- EMPHASIS.BACKGROUND -->
+    <g transform="translate(86.088516 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-30" d="M 269 4666 
+L 1113 4666 
+L 1919 2291 
+L 2731 4666 
+L 3578 4666 
+L 3578 0 
+L 2994 0 
+L 2994 4122 
+L 2163 1663 
+L 1684 1663 
+L 850 4122 
+L 850 0 
+L 269 0 
+L 269 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-33" d="M 1247 4147 
+L 1247 2394 
+L 1978 2394 
+Q 2416 2394 2661 2625 
+Q 2906 2856 2906 3272 
+Q 2906 3688 2662 3917 
+Q 2419 4147 1978 4147 
+L 1247 4147 
+z
+M 616 4666 
+L 1978 4666 
+Q 2759 4666 3162 4311 
+Q 3566 3956 3566 3272 
+Q 3566 2581 3164 2228 
+Q 2763 1875 1978 1875 
+L 1247 1875 
+L 1247 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2b" d="M 428 4666 
+L 1063 4666 
+L 1063 2753 
+L 2791 2753 
+L 2791 4666 
+L 3425 4666 
+L 3425 0 
+L 2791 0 
+L 2791 2222 
+L 1063 2222 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-25" d="M 1153 2228 
+L 1153 519 
+L 1900 519 
+Q 2450 519 2684 711 
+Q 2919 903 2919 1344 
+Q 2919 1800 2672 2014 
+Q 2425 2228 1900 2228 
+L 1153 2228 
+z
+M 1153 4147 
+L 1153 2741 
+L 1888 2741 
+Q 2344 2741 2548 2916 
+Q 2753 3091 2753 3481 
+Q 2753 3834 2551 3990 
+Q 2350 4147 1888 4147 
+L 1153 4147 
+z
+M 519 4666 
+L 1900 4666 
+Q 2616 4666 3003 4356 
+Q 3391 4047 3391 3481 
+Q 3391 3053 3186 2806 
+Q 2981 2559 2572 2497 
+Q 3031 2428 3292 2104 
+Q 3553 1781 3553 1281 
+Q 3553 647 3137 323 
+Q 2722 0 1900 0 
+L 519 0 
+L 519 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-26" d="M 3353 166 
+Q 3113 38 2859 -26 
+Q 2606 -91 2322 -91 
+Q 1425 -91 929 543 
+Q 434 1178 434 2328 
+Q 434 3472 932 4111 
+Q 1431 4750 2322 4750 
+Q 2606 4750 2859 4686 
+Q 3113 4622 3353 4494 
+L 3353 3847 
+Q 3122 4038 2856 4138 
+Q 2591 4238 2322 4238 
+Q 1706 4238 1400 3763 
+Q 1094 3288 1094 2328 
+Q 1094 1372 1400 897 
+Q 1706 422 2322 422 
+Q 2597 422 2861 522 
+Q 3125 622 3353 813 
+L 3353 166 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2e" d="M 428 4666 
+L 1063 4666 
+L 1063 2591 
+L 3034 4666 
+L 3775 4666 
+L 1959 2759 
+L 3828 0 
+L 3066 0 
+L 1544 2338 
+L 1063 1825 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2a" d="M 3450 384 
+Q 3197 150 2880 29 
+Q 2563 -91 2194 -91 
+Q 1306 -91 812 545 
+Q 319 1181 319 2328 
+Q 319 3472 819 4111 
+Q 1319 4750 2209 4750 
+Q 2503 4750 2772 4667 
+Q 3041 4584 3291 4416 
+L 3291 3769 
+Q 3038 4009 2772 4123 
+Q 2506 4238 2209 4238 
+Q 1594 4238 1286 3761 
+Q 978 3284 978 2328 
+Q 978 1356 1276 889 
+Q 1575 422 2194 422 
+Q 2403 422 2561 470 
+Q 2719 519 2847 622 
+L 2847 1875 
+L 2169 1875 
+L 2169 2394 
+L 3450 2394 
+L 3450 384 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-38" d="M 459 1791 
+L 459 4666 
+L 1094 4666 
+L 1094 1503 
+Q 1094 1163 1112 1017 
+Q 1131 872 1178 794 
+Q 1278 609 1467 515 
+Q 1656 422 1925 422 
+Q 2197 422 2384 515 
+Q 2572 609 2675 794 
+Q 2722 872 2740 1015 
+Q 2759 1159 2759 1497 
+L 2759 4666 
+L 3391 4666 
+L 3391 1791 
+Q 3391 1075 3302 773 
+Q 3213 472 2994 275 
+Q 2788 91 2522 0 
+Q 2256 -91 1925 -91 
+Q 1597 -91 1331 0 
+Q 1066 91 856 275 
+Q 641 469 550 776 
+Q 459 1084 459 1791 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-31" d="M 434 4666 
+L 1234 4666 
+L 2809 825 
+L 2809 4666 
+L 3419 4666 
+L 3419 0 
+L 2619 0 
+L 1044 3841 
+L 1044 0 
+L 434 0 
+L 434 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-27" d="M 1363 519 
+Q 2159 519 2475 911 
+Q 2791 1303 2791 2328 
+Q 2791 3363 2477 3755 
+Q 2163 4147 1363 4147 
+L 1063 4147 
+L 1063 519 
+L 1363 519 
+z
+M 1375 4666 
+Q 2444 4666 2950 4097 
+Q 3456 3528 3456 2328 
+Q 3456 1134 2950 567 
+Q 2444 0 1375 0 
+L 428 0 
+L 428 4666 
+L 1375 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-28"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-25" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2e" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-38" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(1083.65625 0)"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_3">
+     <path d="M 26.74899 62.616641 
+L 79.02274 62.616641 
+Q 80.62274 62.616641 80.62274 61.016641 
+L 80.62274 25.637891 
+Q 80.62274 24.037891 79.02274 24.037891 
+L 26.74899 24.037891 
+Q 25.14899 24.037891 25.14899 25.637891 
+L 25.14899 61.016641 
+Q 25.14899 62.616641 26.74899 62.616641 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_12">
+     <!-- Legend -->
+     <g transform="translate(28.34899 33.987891) scale(0.09 -0.09)">
+      <defs>
+       <path id="Helvetica-2f" d="M 488 4591 
+L 1109 4591 
+L 1109 547 
+L 3434 547 
+L 3434 0 
+L 488 0 
+L 488 4591 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-48" d="M 1806 3422 
+Q 2163 3422 2497 3255 
+Q 2831 3088 3006 2822 
+Q 3175 2569 3231 2231 
+Q 3281 2000 3281 1494 
+L 828 1494 
+Q 844 984 1069 676 
+Q 1294 369 1766 369 
+Q 2206 369 2469 659 
+Q 2619 828 2681 1050 
+L 3234 1050 
+Q 3213 866 3089 639 
+Q 2966 413 2813 269 
+Q 2556 19 2178 -69 
+Q 1975 -119 1719 -119 
+Q 1094 -119 659 336 
+Q 225 791 225 1609 
+Q 225 2416 662 2919 
+Q 1100 3422 1806 3422 
+z
+M 2703 1941 
+Q 2669 2306 2544 2525 
+Q 2313 2931 1772 2931 
+Q 1384 2931 1121 2651 
+Q 859 2372 844 1941 
+L 2703 1941 
+z
+M 1753 3428 
+L 1753 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-4a" d="M 1594 3406 
+Q 1988 3406 2281 3213 
+Q 2441 3103 2606 2894 
+L 2606 3316 
+L 3125 3316 
+L 3125 272 
+Q 3125 -366 2938 -734 
+Q 2588 -1416 1616 -1416 
+Q 1075 -1416 706 -1173 
+Q 338 -931 294 -416 
+L 866 -416 
+Q 906 -641 1028 -763 
+Q 1219 -950 1628 -950 
+Q 2275 -950 2475 -494 
+Q 2594 -225 2584 466 
+Q 2416 209 2178 84 
+Q 1941 -41 1550 -41 
+Q 1006 -41 598 345 
+Q 191 731 191 1622 
+Q 191 2463 602 2934 
+Q 1013 3406 1594 3406 
+z
+M 2606 1688 
+Q 2606 2309 2350 2609 
+Q 2094 2909 1697 2909 
+Q 1103 2909 884 2353 
+Q 769 2056 769 1575 
+Q 769 1009 998 714 
+Q 1228 419 1616 419 
+Q 2222 419 2469 966 
+Q 2606 1275 2606 1688 
+z
+M 1659 3428 
+L 1659 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-51" d="M 413 3347 
+L 947 3347 
+L 947 2872 
+Q 1184 3166 1450 3294 
+Q 1716 3422 2041 3422 
+Q 2753 3422 3003 2925 
+Q 3141 2653 3141 2147 
+L 3141 0 
+L 2569 0 
+L 2569 2109 
+Q 2569 2416 2478 2603 
+Q 2328 2916 1934 2916 
+Q 1734 2916 1606 2875 
+Q 1375 2806 1200 2600 
+Q 1059 2434 1017 2257 
+Q 975 2081 975 1753 
+L 975 0 
+L 413 0 
+L 413 3347 
+z
+M 1734 3428 
+L 1734 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-47" d="M 769 1634 
+Q 769 1097 997 734 
+Q 1225 372 1728 372 
+Q 2119 372 2370 708 
+Q 2622 1044 2622 1672 
+Q 2622 2306 2362 2611 
+Q 2103 2916 1722 2916 
+Q 1297 2916 1033 2591 
+Q 769 2266 769 1634 
+z
+M 1616 3406 
+Q 2000 3406 2259 3244 
+Q 2409 3150 2600 2916 
+L 2600 4606 
+L 3141 4606 
+L 3141 0 
+L 2634 0 
+L 2634 466 
+Q 2438 156 2169 18 
+Q 1900 -119 1553 -119 
+Q 994 -119 584 351 
+Q 175 822 175 1603 
+Q 175 2334 548 2870 
+Q 922 3406 1616 3406 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#Helvetica-2f"/>
+      <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-4a" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(166.828125 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(222.4375 0)"/>
+      <use xlink:href="#Helvetica-47" transform="translate(278.046875 0)"/>
+     </g>
+    </g>
+    <g id="line2d_18">
+     <path d="M 28.34899 43.179141 
+L 36.34899 43.179141 
+L 44.34899 43.179141 
+" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_13">
+     <!-- alpha -->
+     <g transform="translate(50.74899 45.979141) scale(0.08 -0.08)">
+      <defs>
+       <path id="Helvetica-44" d="M 844 891 
+Q 844 647 1022 506 
+Q 1200 366 1444 366 
+Q 1741 366 2019 503 
+Q 2488 731 2488 1250 
+L 2488 1703 
+Q 2384 1638 2221 1594 
+Q 2059 1550 1903 1531 
+L 1563 1488 
+Q 1256 1447 1103 1359 
+Q 844 1213 844 891 
+z
+M 2206 2028 
+Q 2400 2053 2466 2191 
+Q 2503 2266 2503 2406 
+Q 2503 2694 2298 2823 
+Q 2094 2953 1713 2953 
+Q 1272 2953 1088 2716 
+Q 984 2584 953 2325 
+L 428 2325 
+Q 444 2944 830 3186 
+Q 1216 3428 1725 3428 
+Q 2316 3428 2684 3203 
+Q 3050 2978 3050 2503 
+L 3050 575 
+Q 3050 488 3086 434 
+Q 3122 381 3238 381 
+Q 3275 381 3322 386 
+Q 3369 391 3422 400 
+L 3422 -16 
+Q 3291 -53 3222 -62 
+Q 3153 -72 3034 -72 
+Q 2744 -72 2613 134 
+Q 2544 244 2516 444 
+Q 2344 219 2022 53 
+Q 1700 -113 1313 -113 
+Q 847 -113 551 170 
+Q 256 453 256 878 
+Q 256 1344 547 1600 
+Q 838 1856 1309 1916 
+L 2206 2028 
+z
+M 1741 3428 
+L 1741 3428 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-4f" d="M 428 4591 
+L 991 4591 
+L 991 0 
+L 428 0 
+L 428 4591 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-53" d="M 1825 378 
+Q 2219 378 2480 708 
+Q 2741 1038 2741 1694 
+Q 2741 2094 2625 2381 
+Q 2406 2934 1825 2934 
+Q 1241 2934 1025 2350 
+Q 909 2038 909 1556 
+Q 909 1169 1025 897 
+Q 1244 378 1825 378 
+z
+M 369 3331 
+L 916 3331 
+L 916 2888 
+Q 1084 3116 1284 3241 
+Q 1569 3428 1953 3428 
+Q 2522 3428 2919 2992 
+Q 3316 2556 3316 1747 
+Q 3316 653 2744 184 
+Q 2381 -113 1900 -113 
+Q 1522 -113 1266 53 
+Q 1116 147 931 375 
+L 931 -1334 
+L 369 -1334 
+L 369 3331 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-4b" d="M 413 4606 
+L 975 4606 
+L 975 2894 
+Q 1175 3147 1334 3250 
+Q 1606 3428 2013 3428 
+Q 2741 3428 3000 2919 
+Q 3141 2641 3141 2147 
+L 3141 0 
+L 2563 0 
+L 2563 2109 
+Q 2563 2478 2469 2650 
+Q 2316 2925 1894 2925 
+Q 1544 2925 1259 2684 
+Q 975 2444 975 1775 
+L 975 0 
+L 413 0 
+L 413 4606 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#Helvetica-44"/>
+      <use xlink:href="#Helvetica-4f" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-53" transform="translate(77.828125 0)"/>
+      <use xlink:href="#Helvetica-4b" transform="translate(133.4375 0)"/>
+      <use xlink:href="#Helvetica-44" transform="translate(189.046875 0)"/>
+     </g>
+    </g>
+    <g id="line2d_19">
+     <path d="M 28.34899 54.846641 
+L 36.34899 54.846641 
+L 44.34899 54.846641 
+" style="fill: none; stroke: #f28e2b; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_14">
+     <!-- gamma -->
+     <g transform="translate(50.74899 57.646641) scale(0.08 -0.08)">
+      <defs>
+       <path id="Helvetica-50" d="M 413 3347 
+L 969 3347 
+L 969 2872 
+Q 1169 3119 1331 3231 
+Q 1609 3422 1963 3422 
+Q 2363 3422 2606 3225 
+Q 2744 3113 2856 2894 
+Q 3044 3163 3297 3292 
+Q 3550 3422 3866 3422 
+Q 4541 3422 4784 2934 
+Q 4916 2672 4916 2228 
+L 4916 0 
+L 4331 0 
+L 4331 2325 
+Q 4331 2659 4164 2784 
+Q 3997 2909 3756 2909 
+Q 3425 2909 3186 2687 
+Q 2947 2466 2947 1947 
+L 2947 0 
+L 2375 0 
+L 2375 2184 
+Q 2375 2525 2294 2681 
+Q 2166 2916 1816 2916 
+Q 1497 2916 1236 2669 
+Q 975 2422 975 1775 
+L 975 0 
+L 413 0 
+L 413 3347 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#Helvetica-4a"/>
+      <use xlink:href="#Helvetica-44" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-50" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-50" transform="translate(194.515625 0)"/>
+      <use xlink:href="#Helvetica-44" transform="translate(277.8125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_4">
+    <path d="M 21.14899 160.140145 
+L 21.14899 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 21.14899 160.140145 
+L 253.975385 160.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_6">
+    <path d="M 273.14899 160.140145 
+L 505.975385 160.140145 
+L 505.975385 20.037891 
+L 273.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_7">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m40c17b1354" x="273.14899" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0 -->
+      <g transform="translate(270.924615 172.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m40c17b1354" x="319.714269" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 1 -->
+      <g transform="translate(317.489894 172.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m40c17b1354" x="366.279548" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 2 -->
+      <g transform="translate(364.055173 172.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m40c17b1354" x="412.844827" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 3 -->
+      <g transform="translate(410.620452 172.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m40c17b1354" x="459.410106" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 4 -->
+      <g transform="translate(457.185731 172.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m40c17b1354" x="505.975385" y="160.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 5 -->
+      <g transform="translate(503.75101 172.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_26">
+      <path d="M 273.14899 137.85115 
+L 505.975385 137.85115 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="137.85115" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 2 -->
+      <g transform="translate(262.20024 140.85115) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_28">
+      <path d="M 273.14899 106.009729 
+L 505.975385 106.009729 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="106.009729" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 4 -->
+      <g transform="translate(262.20024 109.009729) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_30">
+      <path d="M 273.14899 74.168307 
+L 505.975385 74.168307 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="74.168307" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 6 -->
+      <g transform="translate(262.20024 77.168307) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_32">
+      <path d="M 273.14899 42.326886 
+L 505.975385 42.326886 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m2aeb96f9fe" x="273.14899" y="42.326886" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 8 -->
+      <g transform="translate(262.20024 45.326886) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-1b"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_34">
+    <path d="M 273.14899 153.771861 
+L 319.714269 121.930439 
+L 366.279548 137.85115 
+L 412.844827 90.089018 
+L 459.410106 106.009729 
+L 505.975385 74.168307 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_35">
+    <path d="M 273.14899 106.009729 
+L 319.714269 74.168307 
+L 366.279548 90.089018 
+L 412.844827 42.326886 
+L 459.410106 58.247596 
+L 505.975385 26.406175 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #59a14f; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_25">
+    <!-- EMPHASIS.HIGHLIGHT -->
+    <g transform="translate(340.797656 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-28"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(1023.453125 0)"/>
+    </g>
+   </g>
+   <g id="line2d_36">
+    <path d="M 273.14899 129.890795 
+L 319.714269 98.049373 
+L 366.279548 113.970084 
+L 412.844827 66.207952 
+L 459.410106 82.128662 
+L 505.975385 50.287241 
+" clip-path="url(#p12ebfd7627)" style="fill: none; stroke: #f28e2b; stroke-width: 3; stroke-linecap: square"/>
+   </g>
+   <g id="legend_2">
+    <g id="patch_7">
+     <path d="M 278.74899 73.976016 
+L 331.02274 73.976016 
+Q 332.62274 73.976016 332.62274 72.376016 
+L 332.62274 25.637891 
+Q 332.62274 24.037891 331.02274 24.037891 
+L 278.74899 24.037891 
+Q 277.14899 24.037891 277.14899 25.637891 
+L 277.14899 72.376016 
+Q 277.14899 73.976016 278.74899 73.976016 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="text_26">
+     <!-- Legend -->
+     <g transform="translate(280.34899 33.987891) scale(0.09 -0.09)">
+      <use xlink:href="#Helvetica-2f"/>
+      <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-4a" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-48" transform="translate(166.828125 0)"/>
+      <use xlink:href="#Helvetica-51" transform="translate(222.4375 0)"/>
+      <use xlink:href="#Helvetica-47" transform="translate(278.046875 0)"/>
+     </g>
+    </g>
+    <g id="line2d_37">
+     <path d="M 280.34899 43.179141 
+L 288.34899 43.179141 
+L 296.34899 43.179141 
+" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_27">
+     <!-- alpha -->
+     <g transform="translate(302.74899 45.979141) scale(0.08 -0.08)">
+      <use xlink:href="#Helvetica-44"/>
+      <use xlink:href="#Helvetica-4f" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-53" transform="translate(77.828125 0)"/>
+      <use xlink:href="#Helvetica-4b" transform="translate(133.4375 0)"/>
+      <use xlink:href="#Helvetica-44" transform="translate(189.046875 0)"/>
+     </g>
+    </g>
+    <g id="line2d_38">
+     <path d="M 280.34899 54.846641 
+L 288.34899 54.846641 
+L 296.34899 54.846641 
+" style="fill: none; stroke: #f28e2b; stroke-width: 3; stroke-linecap: square"/>
+    </g>
+    <g id="text_28">
+     <!-- beta -->
+     <g transform="translate(302.74899 57.646641) scale(0.08 -0.08)">
+      <defs>
+       <path id="Helvetica-45" d="M 369 4606 
+L 916 4606 
+L 916 2941 
+Q 1100 3181 1356 3307 
+Q 1613 3434 1913 3434 
+Q 2538 3434 2927 3004 
+Q 3316 2575 3316 1738 
+Q 3316 944 2931 419 
+Q 2547 -106 1866 -106 
+Q 1484 -106 1222 78 
+Q 1066 188 888 428 
+L 888 0 
+L 369 0 
+L 369 4606 
+z
+M 1831 391 
+Q 2288 391 2514 753 
+Q 2741 1116 2741 1709 
+Q 2741 2238 2514 2584 
+Q 2288 2931 1847 2931 
+Q 1463 2931 1173 2647 
+Q 884 2363 884 1709 
+Q 884 1238 1003 944 
+Q 1225 391 1831 391 
+z
+" transform="scale(0.015625)"/>
+       <path id="Helvetica-57" d="M 525 4281 
+L 1094 4281 
+L 1094 3347 
+L 1628 3347 
+L 1628 2888 
+L 1094 2888 
+L 1094 703 
+Q 1094 528 1213 469 
+Q 1278 434 1431 434 
+Q 1472 434 1519 436 
+Q 1566 438 1628 444 
+L 1628 0 
+Q 1531 -28 1426 -40 
+Q 1322 -53 1200 -53 
+Q 806 -53 665 148 
+Q 525 350 525 672 
+L 525 2888 
+L 72 2888 
+L 72 3347 
+L 525 3347 
+L 525 4281 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#Helvetica-45"/>
+      <use xlink:href="#Helvetica-48" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-57" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-44" transform="translate(139 0)"/>
+     </g>
+    </g>
+    <g id="line2d_39">
+     <path d="M 280.34899 66.206016 
+L 288.34899 66.206016 
+L 296.34899 66.206016 
+" style="fill: none; stroke: #59a14f; stroke-width: 1.5; stroke-linecap: square"/>
+    </g>
+    <g id="text_29">
+     <!-- gamma -->
+     <g transform="translate(302.74899 69.006016) scale(0.08 -0.08)">
+      <use xlink:href="#Helvetica-4a"/>
+      <use xlink:href="#Helvetica-44" transform="translate(55.609375 0)"/>
+      <use xlink:href="#Helvetica-50" transform="translate(111.21875 0)"/>
+      <use xlink:href="#Helvetica-50" transform="translate(194.515625 0)"/>
+      <use xlink:href="#Helvetica-44" transform="translate(277.8125 0)"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 273.14899 160.140145 
+L 273.14899 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 273.14899 160.140145 
+L 505.975385 160.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_30">
+   <!-- The "beta" series carries the emphasis role; BACKGROUND also drops its legend entry. -->
+   <g transform="translate(7.2 182.18376) scale(0.085 -0.085)">
+    <defs>
+     <path id="DejaVuSans-Oblique-37" d="M 378 4666 
+L 4325 4666 
+L 4225 4134 
+L 2559 4134 
+L 1759 0 
+L 1125 0 
+L 1925 4134 
+L 275 4134 
+L 378 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5" d="M 1147 4666 
+L 1147 2931 
+L 616 2931 
+L 616 4666 
+L 1147 4666 
+z
+M 2328 4666 
+L 2328 2931 
+L 1797 2931 
+L 1797 4666 
+L 2328 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-45" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-25" d="M 1081 4666 
+L 2694 4666 
+Q 3350 4666 3675 4422 
+Q 4000 4178 4000 3688 
+Q 4000 3238 3720 2911 
+Q 3441 2584 2988 2516 
+Q 3375 2428 3569 2181 
+Q 3763 1934 3763 1522 
+Q 3763 819 3242 409 
+Q 2722 0 1819 0 
+L 172 0 
+L 1081 4666 
+z
+M 1234 2228 
+L 903 519 
+L 1919 519 
+Q 2491 519 2800 781 
+Q 3109 1044 3109 1522 
+Q 3109 1891 2904 2059 
+Q 2700 2228 2247 2228 
+L 1234 2228 
+z
+M 1606 4147 
+L 1331 2741 
+L 2272 2741 
+Q 2775 2741 3058 2959 
+Q 3341 3178 3341 3566 
+Q 3341 3869 3150 4008 
+Q 2959 4147 2541 4147 
+L 1606 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-24" d="M 2356 4666 
+L 3072 4666 
+L 3938 0 
+L 3278 0 
+L 3084 1197 
+L 984 1197 
+L 325 0 
+L -341 0 
+L 2356 4666 
+z
+M 2584 4044 
+L 1275 1722 
+L 2988 1722 
+L 2584 4044 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-26" d="M 4447 4306 
+L 4319 3641 
+Q 4019 3944 3683 4091 
+Q 3347 4238 2956 4238 
+Q 2422 4238 2017 3981 
+Q 1613 3725 1319 3200 
+Q 1131 2863 1032 2486 
+Q 934 2109 934 1728 
+Q 934 1091 1264 756 
+Q 1594 422 2222 422 
+Q 2656 422 3056 561 
+Q 3456 700 3834 978 
+L 3688 231 
+Q 3316 72 2936 -9 
+Q 2556 -91 2175 -91 
+Q 1278 -91 773 396 
+Q 269 884 269 1753 
+Q 269 2309 461 2846 
+Q 653 3384 1013 3828 
+Q 1394 4300 1883 4525 
+Q 2372 4750 3022 4750 
+Q 3422 4750 3780 4639 
+Q 4138 4528 4447 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 1081 4666 
+L 1716 4666 
+L 1331 2700 
+L 3781 4666 
+L 4622 4666 
+L 1850 2438 
+L 3878 0 
+L 3109 0 
+L 1247 2272 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2a" d="M 3494 697 
+L 3738 1919 
+L 2700 1919 
+L 2797 2438 
+L 4453 2438 
+L 4050 384 
+Q 3634 156 3143 32 
+Q 2653 -91 2156 -91 
+Q 1278 -91 783 396 
+Q 288 884 288 1753 
+Q 288 2475 589 3126 
+Q 891 3778 1422 4213 
+Q 1756 4484 2153 4617 
+Q 2550 4750 3034 4750 
+Q 3472 4750 3873 4639 
+Q 4275 4528 4641 4306 
+L 4513 3634 
+Q 4231 3928 3853 4083 
+Q 3475 4238 3047 4238 
+Q 2550 4238 2172 4048 
+Q 1794 3859 1497 3463 
+Q 1244 3125 1098 2667 
+Q 953 2209 953 1734 
+Q 953 1081 1287 751 
+Q 1622 422 2284 422 
+Q 2616 422 2925 492 
+Q 3234 563 3494 697 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-35" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-32" d="M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+M 2100 -91 
+Q 1241 -91 748 418 
+Q 256 928 256 1813 
+Q 256 2319 448 2847 
+Q 641 3375 978 3788 
+Q 1375 4272 1862 4511 
+Q 2350 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 2331 4593 1812 
+Q 4406 1294 4056 872 
+Q 3656 384 3173 146 
+Q 2691 -91 2100 -91 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-38" d="M 991 4666 
+L 1625 4666 
+L 1075 1831 
+Q 1041 1641 1027 1517 
+Q 1013 1394 1013 1300 
+Q 1013 869 1253 645 
+Q 1494 422 1959 422 
+Q 2563 422 2898 753 
+Q 3234 1084 3378 1831 
+L 3928 4666 
+L 4563 4666 
+L 4000 1753 
+Q 3816 809 3300 359 
+Q 2784 -91 1888 -91 
+Q 1188 -91 780 261 
+Q 372 613 372 1216 
+Q 372 1325 387 1461 
+Q 403 1597 434 1753 
+L 991 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-31" d="M 1081 4666 
+L 1931 4666 
+L 3219 666 
+L 4000 4666 
+L 4616 4666 
+L 3706 0 
+L 2853 0 
+L 1569 4025 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-27" d="M 1081 4666 
+L 2438 4666 
+Q 3519 4666 4070 4208 
+Q 4622 3750 4622 2847 
+Q 4622 2250 4412 1698 
+Q 4203 1147 3834 769 
+Q 3463 381 2891 190 
+Q 2319 0 1538 0 
+L 172 0 
+L 1081 4666 
+z
+M 1613 4147 
+L 909 519 
+L 1734 519 
+Q 2794 519 3375 1128 
+Q 3956 1738 3956 2847 
+Q 3956 3519 3581 3833 
+Q 3206 4147 2406 4147 
+L 1613 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5c" d="M 1588 -325 
+Q 1188 -997 936 -1164 
+Q 684 -1331 294 -1331 
+L -159 -1331 
+L -63 -850 
+L 269 -850 
+Q 509 -850 678 -719 
+Q 847 -588 1056 -206 
+L 1234 128 
+L 459 3500 
+L 1069 3500 
+L 1650 819 
+L 3256 3500 
+L 3859 3500 
+L 1588 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-11" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-37"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(61.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(124.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(185.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5" transform="translate(217.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-45" transform="translate(263.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(327.25 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(388.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(427.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5" transform="translate(489.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(535.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(567.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(619.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(680.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(721.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(749.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(811.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(863.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(894.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(949.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1011.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1052.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1093.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1121.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1182.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1234.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(1266.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1305.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1369.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1430.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1462.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(1524.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(1621.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1684.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1748.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1809.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1861.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1889.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1941.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1973.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(2014.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(2075.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2103.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(2164.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2198.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(2230.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(2299.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-26" transform="translate(2367.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(2437.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2a" transform="translate(2502.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-35" transform="translate(2580.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-32" transform="translate(2649.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-38" transform="translate(2728.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2801.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-27" transform="translate(2876.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2953.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2985.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(3046.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3074.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3126.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3187.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(3219.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(3282.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3324.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(3385.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3448.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3500.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(3532.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3560.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3599.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3651.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(3683.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3711.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(3772.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3836.25 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(3897.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(3961.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4024.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4056.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(4117.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(4181.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(4220.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(4261.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(4313.0625 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2716e163de">
+   <rect x="21.14899" y="20.037891" width="232.826395" height="140.102254"/>
+  </clipPath>
+  <clipPath id="p12ebfd7627">
+   <rect x="273.14899" y="20.037891" width="232.826395" height="140.102254"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-histogram-type.svg
+++ b/docs/assets/imgs/const-histogram-type.svg
@@ -1,0 +1,2879 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.431172pt" height="295.249752pt" viewBox="0 0 583.431172 295.249752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:25.560287</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 295.249752 
+L 583.431172 295.249752 
+L 583.431172 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 25.59774 124.140145 
+L 256.19976 124.140145 
+L 256.19976 20.037891 
+L 25.59774 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="me33b082665" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#me33b082665" x="57.755191" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- −2 -->
+      <g transform="translate(53.194566 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-ef" d="M 3547 1894 
+L 3547 1369 
+L 288 1369 
+L 288 1894 
+L 3547 1894 
+z
+" transform="scale(0.015625)"/>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#me33b082665" x="96.006701" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- −1 -->
+      <g transform="translate(91.446076 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#me33b082665" x="134.258211" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0 -->
+      <g transform="translate(132.033836 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#me33b082665" x="172.509721" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1 -->
+      <g transform="translate(170.285346 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#me33b082665" x="210.761231" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 2 -->
+      <g transform="translate(208.536856 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#me33b082665" x="249.012741" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 3 -->
+      <g transform="translate(246.788366 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_7">
+      <path d="M 25.59774 124.140145 
+L 256.19976 124.140145 
+" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <defs>
+       <path id="mb57cb529fc" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 0 -->
+      <g transform="translate(14.64899 127.140145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_9">
+      <path d="M 25.59774 106.43568 
+L 256.19976 106.43568 
+" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 10 -->
+      <g transform="translate(10.20024 109.43568) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_11">
+      <path d="M 25.59774 88.731215 
+L 256.19976 88.731215 
+" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 20 -->
+      <g transform="translate(10.20024 91.731215) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_13">
+      <path d="M 25.59774 71.02675 
+L 256.19976 71.02675 
+" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 30 -->
+      <g transform="translate(10.20024 74.02675) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_15">
+      <path d="M 25.59774 53.322285 
+L 256.19976 53.322285 
+" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 40 -->
+      <g transform="translate(10.20024 56.322285) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_17">
+      <path d="M 25.59774 35.61782 
+L 256.19976 35.61782 
+" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 50 -->
+      <g transform="translate(10.20024 38.61782) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-18"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 36.07965 124.140145 
+L 46.56156 124.140145 
+L 46.56156 120.599252 
+L 36.07965 120.599252 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 46.56156 124.140145 
+L 57.04347 124.140145 
+L 57.04347 115.287912 
+L 46.56156 115.287912 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 57.04347 124.140145 
+L 67.52538 124.140145 
+L 67.52538 115.287912 
+L 57.04347 115.287912 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 67.52538 124.140145 
+L 78.00729 124.140145 
+L 78.00729 106.43568 
+L 67.52538 106.43568 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 78.00729 124.140145 
+L 88.4892 124.140145 
+L 88.4892 88.731215 
+L 78.00729 88.731215 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 88.4892 124.140145 
+L 98.97111 124.140145 
+L 98.97111 74.567643 
+L 88.4892 74.567643 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 98.97111 124.140145 
+L 109.45302 124.140145 
+L 109.45302 63.944964 
+L 98.97111 63.944964 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 109.45302 124.140145 
+L 119.93493 124.140145 
+L 119.93493 63.944964 
+L 109.45302 63.944964 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 119.93493 124.140145 
+L 130.41684 124.140145 
+L 130.41684 40.929159 
+L 119.93493 40.929159 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 130.41684 124.140145 
+L 140.89875 124.140145 
+L 140.89875 51.551838 
+L 130.41684 51.551838 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 140.89875 124.140145 
+L 151.38066 124.140145 
+L 151.38066 24.995141 
+L 140.89875 24.995141 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 151.38066 124.140145 
+L 161.86257 124.140145 
+L 161.86257 67.485857 
+L 151.38066 67.485857 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 161.86257 124.140145 
+L 172.34448 124.140145 
+L 172.34448 67.485857 
+L 161.86257 67.485857 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 172.34448 124.140145 
+L 182.82639 124.140145 
+L 182.82639 99.353894 
+L 172.34448 99.353894 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 182.82639 124.140145 
+L 193.3083 124.140145 
+L 193.3083 95.813001 
+L 182.82639 95.813001 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 193.3083 124.140145 
+L 203.79021 124.140145 
+L 203.79021 102.894787 
+L 193.3083 102.894787 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 203.79021 124.140145 
+L 214.27212 124.140145 
+L 214.27212 117.058359 
+L 203.79021 117.058359 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 214.27212 124.140145 
+L 224.75403 124.140145 
+L 224.75403 115.287912 
+L 214.27212 115.287912 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 224.75403 124.140145 
+L 235.23594 124.140145 
+L 235.23594 122.369698 
+L 224.75403 122.369698 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 235.23594 124.140145 
+L 245.71785 124.140145 
+L 245.71785 120.599252 
+L 235.23594 120.599252 
+z
+" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_13">
+    <!-- HISTOGRAM_TYPE.BAR -->
+    <g transform="translate(92.134219 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-2b" d="M 428 4666 
+L 1063 4666 
+L 1063 2753 
+L 2791 2753 
+L 2791 4666 
+L 3425 4666 
+L 3425 0 
+L 2791 0 
+L 2791 2222 
+L 1063 2222 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2a" d="M 3450 384 
+Q 3197 150 2880 29 
+Q 2563 -91 2194 -91 
+Q 1306 -91 812 545 
+Q 319 1181 319 2328 
+Q 319 3472 819 4111 
+Q 1319 4750 2209 4750 
+Q 2503 4750 2772 4667 
+Q 3041 4584 3291 4416 
+L 3291 3769 
+Q 3038 4009 2772 4123 
+Q 2506 4238 2209 4238 
+Q 1594 4238 1286 3761 
+Q 978 3284 978 2328 
+Q 978 1356 1276 889 
+Q 1575 422 2194 422 
+Q 2403 422 2561 470 
+Q 2719 519 2847 622 
+L 2847 1875 
+L 2169 1875 
+L 2169 2394 
+L 3450 2394 
+L 3450 384 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-30" d="M 269 4666 
+L 1113 4666 
+L 1919 2291 
+L 2731 4666 
+L 3578 4666 
+L 3578 0 
+L 2994 0 
+L 2994 4122 
+L 2163 1663 
+L 1684 1663 
+L 850 4122 
+L 850 0 
+L 269 0 
+L 269 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-42" d="M 3853 -1259 
+L 3853 -1509 
+L 0 -1509 
+L 0 -1259 
+L 3853 -1259 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-3c" d="M 116 4666 
+L 788 4666 
+L 1925 2606 
+L 3059 4666 
+L 3738 4666 
+L 2241 2094 
+L 2241 0 
+L 1606 0 
+L 1606 2094 
+L 116 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-33" d="M 1247 4147 
+L 1247 2394 
+L 1978 2394 
+Q 2416 2394 2661 2625 
+Q 2906 2856 2906 3272 
+Q 2906 3688 2662 3917 
+Q 2419 4147 1978 4147 
+L 1247 4147 
+z
+M 616 4666 
+L 1978 4666 
+Q 2759 4666 3162 4311 
+Q 3566 3956 3566 3272 
+Q 3566 2581 3164 2228 
+Q 2763 1875 1978 1875 
+L 1247 1875 
+L 1247 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-25" d="M 1153 2228 
+L 1153 519 
+L 1900 519 
+Q 2450 519 2684 711 
+Q 2919 903 2919 1344 
+Q 2919 1800 2672 2014 
+Q 2425 2228 1900 2228 
+L 1153 2228 
+z
+M 1153 4147 
+L 1153 2741 
+L 1888 2741 
+Q 2344 2741 2548 2916 
+Q 2753 3091 2753 3481 
+Q 2753 3834 2551 3990 
+Q 2350 4147 1888 4147 
+L 1153 4147 
+z
+M 519 4666 
+L 1900 4666 
+Q 2616 4666 3003 4356 
+Q 3391 4047 3391 3481 
+Q 3391 3053 3186 2806 
+Q 2981 2559 2572 2497 
+Q 3031 2428 3292 2104 
+Q 3553 1781 3553 1281 
+Q 3553 647 3137 323 
+Q 2722 0 1900 0 
+L 519 0 
+L 519 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-2b"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-25" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(1023.453125 0)"/>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 25.59774 124.140145 
+L 25.59774 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 25.59774 124.140145 
+L 256.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_25">
+    <path d="M 277.59774 124.140145 
+L 508.19976 124.140145 
+L 508.19976 20.037891 
+L 277.59774 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_7">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#me33b082665" x="309.755191" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- −2 -->
+      <g transform="translate(305.194566 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#me33b082665" x="348.006701" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- −1 -->
+      <g transform="translate(343.446076 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#me33b082665" x="386.258211" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 0 -->
+      <g transform="translate(384.033836 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#me33b082665" x="424.509721" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 1 -->
+      <g transform="translate(422.285346 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#me33b082665" x="462.761231" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 2 -->
+      <g transform="translate(460.536856 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#me33b082665" x="501.012741" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 3 -->
+      <g transform="translate(498.788366 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_25">
+      <path d="M 277.59774 124.140145 
+L 508.19976 124.140145 
+" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 0 -->
+      <g transform="translate(266.64899 127.140145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_27">
+      <path d="M 277.59774 106.43568 
+L 508.19976 106.43568 
+" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 10 -->
+      <g transform="translate(262.20024 109.43568) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_29">
+      <path d="M 277.59774 88.731215 
+L 508.19976 88.731215 
+" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 20 -->
+      <g transform="translate(262.20024 91.731215) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_31">
+      <path d="M 277.59774 71.02675 
+L 508.19976 71.02675 
+" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 30 -->
+      <g transform="translate(262.20024 74.02675) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_33">
+      <path d="M 277.59774 53.322285 
+L 508.19976 53.322285 
+" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 40 -->
+      <g transform="translate(262.20024 56.322285) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_35">
+      <path d="M 277.59774 35.61782 
+L 508.19976 35.61782 
+" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 50 -->
+      <g transform="translate(262.20024 38.61782) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_26">
+    <path d="M 288.07965 124.140145 
+L 298.56156 124.140145 
+L 298.56156 120.599252 
+L 288.07965 120.599252 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_27">
+    <path d="M 298.56156 124.140145 
+L 309.04347 124.140145 
+L 309.04347 115.287912 
+L 298.56156 115.287912 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 309.04347 124.140145 
+L 319.52538 124.140145 
+L 319.52538 115.287912 
+L 309.04347 115.287912 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_29">
+    <path d="M 319.52538 124.140145 
+L 330.00729 124.140145 
+L 330.00729 106.43568 
+L 319.52538 106.43568 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_30">
+    <path d="M 330.00729 124.140145 
+L 340.4892 124.140145 
+L 340.4892 88.731215 
+L 330.00729 88.731215 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_31">
+    <path d="M 340.4892 124.140145 
+L 350.97111 124.140145 
+L 350.97111 74.567643 
+L 340.4892 74.567643 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_32">
+    <path d="M 350.97111 124.140145 
+L 361.45302 124.140145 
+L 361.45302 63.944964 
+L 350.97111 63.944964 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_33">
+    <path d="M 361.45302 124.140145 
+L 371.93493 124.140145 
+L 371.93493 63.944964 
+L 361.45302 63.944964 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_34">
+    <path d="M 371.93493 124.140145 
+L 382.41684 124.140145 
+L 382.41684 40.929159 
+L 371.93493 40.929159 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 382.41684 124.140145 
+L 392.89875 124.140145 
+L 392.89875 51.551838 
+L 382.41684 51.551838 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 392.89875 124.140145 
+L 403.38066 124.140145 
+L 403.38066 24.995141 
+L 392.89875 24.995141 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 403.38066 124.140145 
+L 413.86257 124.140145 
+L 413.86257 67.485857 
+L 403.38066 67.485857 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 413.86257 124.140145 
+L 424.34448 124.140145 
+L 424.34448 67.485857 
+L 413.86257 67.485857 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 424.34448 124.140145 
+L 434.82639 124.140145 
+L 434.82639 99.353894 
+L 424.34448 99.353894 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 434.82639 124.140145 
+L 445.3083 124.140145 
+L 445.3083 95.813001 
+L 434.82639 95.813001 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 445.3083 124.140145 
+L 455.79021 124.140145 
+L 455.79021 102.894787 
+L 445.3083 102.894787 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 455.79021 124.140145 
+L 466.27212 124.140145 
+L 466.27212 117.058359 
+L 455.79021 117.058359 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 466.27212 124.140145 
+L 476.75403 124.140145 
+L 476.75403 115.287912 
+L 466.27212 115.287912 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 476.75403 124.140145 
+L 487.23594 124.140145 
+L 487.23594 122.369698 
+L 476.75403 122.369698 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 487.23594 124.140145 
+L 497.71785 124.140145 
+L 497.71785 120.599252 
+L 487.23594 120.599252 
+z
+" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_26">
+    <!-- HISTOGRAM_TYPE.BAR_STACKED -->
+    <g transform="translate(322.461094 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-26" d="M 3353 166 
+Q 3113 38 2859 -26 
+Q 2606 -91 2322 -91 
+Q 1425 -91 929 543 
+Q 434 1178 434 2328 
+Q 434 3472 932 4111 
+Q 1431 4750 2322 4750 
+Q 2606 4750 2859 4686 
+Q 3113 4622 3353 4494 
+L 3353 3847 
+Q 3122 4038 2856 4138 
+Q 2591 4238 2322 4238 
+Q 1706 4238 1400 3763 
+Q 1094 3288 1094 2328 
+Q 1094 1372 1400 897 
+Q 1706 422 2322 422 
+Q 2597 422 2861 522 
+Q 3125 622 3353 813 
+L 3353 166 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2e" d="M 428 4666 
+L 1063 4666 
+L 1063 2591 
+L 3034 4666 
+L 3775 4666 
+L 1959 2759 
+L 3828 0 
+L 3066 0 
+L 1544 2338 
+L 1063 1825 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-27" d="M 1363 519 
+Q 2159 519 2475 911 
+Q 2791 1303 2791 2328 
+Q 2791 3363 2477 3755 
+Q 2163 4147 1363 4147 
+L 1063 4147 
+L 1063 519 
+L 1363 519 
+z
+M 1375 4666 
+Q 2444 4666 2950 4097 
+Q 3456 3528 3456 2328 
+Q 3456 1134 2950 567 
+Q 2444 0 1375 0 
+L 428 0 
+L 428 4666 
+L 1375 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-2b"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-25" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(1083.65625 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(1143.859375 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(1204.0625 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(1264.265625 0)"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(1324.46875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2e" transform="translate(1384.671875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(1444.875 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(1505.078125 0)"/>
+    </g>
+   </g>
+   <g id="patch_46">
+    <path d="M 277.59774 124.140145 
+L 277.59774 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 277.59774 124.140145 
+L 508.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_48">
+    <path d="M 25.59774 260.940145 
+L 256.19976 260.940145 
+L 256.19976 156.837891 
+L 25.59774 156.837891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_13">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#me33b082665" x="57.755191" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- −2 -->
+      <g transform="translate(53.194566 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#me33b082665" x="96.006701" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- −1 -->
+      <g transform="translate(91.446076 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#me33b082665" x="134.258211" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 0 -->
+      <g transform="translate(132.033836 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#me33b082665" x="172.509721" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 1 -->
+      <g transform="translate(170.285346 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#me33b082665" x="210.761231" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 2 -->
+      <g transform="translate(208.536856 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#me33b082665" x="249.012741" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 3 -->
+      <g transform="translate(246.788366 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_13">
+     <g id="line2d_43">
+      <path d="M 25.59774 260.940145 
+L 256.19976 260.940145 
+" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 0 -->
+      <g transform="translate(14.64899 263.940145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_45">
+      <path d="M 25.59774 243.23568 
+L 256.19976 243.23568 
+" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 10 -->
+      <g transform="translate(10.20024 246.23568) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_47">
+      <path d="M 25.59774 225.531215 
+L 256.19976 225.531215 
+" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 20 -->
+      <g transform="translate(10.20024 228.531215) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_49">
+      <path d="M 25.59774 207.82675 
+L 256.19976 207.82675 
+" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 30 -->
+      <g transform="translate(10.20024 210.82675) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_51">
+      <path d="M 25.59774 190.122285 
+L 256.19976 190.122285 
+" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 40 -->
+      <g transform="translate(10.20024 193.122285) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_53">
+      <path d="M 25.59774 172.41782 
+L 256.19976 172.41782 
+" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="25.59774" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 50 -->
+      <g transform="translate(10.20024 175.41782) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_49">
+    <path d="M 36.07965 260.940145 
+L 36.07965 257.399252 
+L 46.56156 257.399252 
+L 46.56156 252.087912 
+L 57.04347 252.087912 
+L 57.04347 252.087912 
+L 67.52538 252.087912 
+L 67.52538 243.23568 
+L 78.00729 243.23568 
+L 78.00729 225.531215 
+L 88.4892 225.531215 
+L 88.4892 211.367643 
+L 98.97111 211.367643 
+L 98.97111 200.744964 
+L 109.45302 200.744964 
+L 109.45302 200.744964 
+L 119.93493 200.744964 
+L 119.93493 177.729159 
+L 130.41684 177.729159 
+L 130.41684 188.351838 
+L 140.89875 188.351838 
+L 140.89875 161.795141 
+L 151.38066 161.795141 
+L 151.38066 204.285857 
+L 161.86257 204.285857 
+L 161.86257 204.285857 
+L 172.34448 204.285857 
+L 172.34448 236.153894 
+L 182.82639 236.153894 
+L 182.82639 232.613001 
+L 193.3083 232.613001 
+L 193.3083 239.694787 
+L 203.79021 239.694787 
+L 203.79021 253.858359 
+L 214.27212 253.858359 
+L 214.27212 252.087912 
+L 224.75403 252.087912 
+L 224.75403 259.169698 
+L 235.23594 259.169698 
+L 235.23594 257.399252 
+L 245.71785 257.399252 
+L 245.71785 260.940145 
+" clip-path="url(#p5faff61a36)" style="fill: none; opacity: 0.9; stroke: #08306b; stroke-width: 1.2; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_39">
+    <!-- HISTOGRAM_TYPE.STEP -->
+    <g transform="translate(89.425078 150.837891) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSansMono-2b"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(1083.65625 0)"/>
+    </g>
+   </g>
+   <g id="patch_50">
+    <path d="M 25.59774 260.940145 
+L 25.59774 156.837891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 25.59774 260.940145 
+L 256.19976 260.940145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_52">
+    <path d="M 277.59774 260.940145 
+L 508.19976 260.940145 
+L 508.19976 156.837891 
+L 277.59774 156.837891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_19">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#me33b082665" x="309.755191" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_40">
+      <!-- −2 -->
+      <g transform="translate(305.194566 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#me33b082665" x="348.006701" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_41">
+      <!-- −1 -->
+      <g transform="translate(343.446076 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#me33b082665" x="386.258211" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <!-- 0 -->
+      <g transform="translate(384.033836 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#me33b082665" x="424.509721" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_43">
+      <!-- 1 -->
+      <g transform="translate(422.285346 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#me33b082665" x="462.761231" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <!-- 2 -->
+      <g transform="translate(460.536856 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#me33b082665" x="501.012741" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_45">
+      <!-- 3 -->
+      <g transform="translate(498.788366 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_19">
+     <g id="line2d_61">
+      <path d="M 277.59774 260.940145 
+L 508.19976 260.940145 
+" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_46">
+      <!-- 0 -->
+      <g transform="translate(266.64899 263.940145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_63">
+      <path d="M 277.59774 243.23568 
+L 508.19976 243.23568 
+" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_47">
+      <!-- 10 -->
+      <g transform="translate(262.20024 246.23568) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_65">
+      <path d="M 277.59774 225.531215 
+L 508.19976 225.531215 
+" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_48">
+      <!-- 20 -->
+      <g transform="translate(262.20024 228.531215) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_67">
+      <path d="M 277.59774 207.82675 
+L 508.19976 207.82675 
+" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_49">
+      <!-- 30 -->
+      <g transform="translate(262.20024 210.82675) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_69">
+      <path d="M 277.59774 190.122285 
+L 508.19976 190.122285 
+" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_50">
+      <!-- 40 -->
+      <g transform="translate(262.20024 193.122285) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_71">
+      <path d="M 277.59774 172.41782 
+L 508.19976 172.41782 
+" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#mb57cb529fc" x="277.59774" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_51">
+      <!-- 50 -->
+      <g transform="translate(262.20024 175.41782) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_53">
+    <path d="M 288.07965 260.940145 
+L 288.07965 257.399252 
+L 298.56156 257.399252 
+L 298.56156 252.087912 
+L 309.04347 252.087912 
+L 309.04347 252.087912 
+L 319.52538 252.087912 
+L 319.52538 243.23568 
+L 330.00729 243.23568 
+L 330.00729 225.531215 
+L 340.4892 225.531215 
+L 340.4892 211.367643 
+L 350.97111 211.367643 
+L 350.97111 200.744964 
+L 361.45302 200.744964 
+L 361.45302 200.744964 
+L 371.93493 200.744964 
+L 371.93493 177.729159 
+L 382.41684 177.729159 
+L 382.41684 188.351838 
+L 392.89875 188.351838 
+L 392.89875 161.795141 
+L 403.38066 161.795141 
+L 403.38066 204.285857 
+L 413.86257 204.285857 
+L 413.86257 204.285857 
+L 424.34448 204.285857 
+L 424.34448 236.153894 
+L 434.82639 236.153894 
+L 434.82639 232.613001 
+L 445.3083 232.613001 
+L 445.3083 239.694787 
+L 455.79021 239.694787 
+L 455.79021 253.858359 
+L 466.27212 253.858359 
+L 466.27212 252.087912 
+L 476.75403 252.087912 
+L 476.75403 259.169698 
+L 487.23594 259.169698 
+L 487.23594 257.399252 
+L 497.71785 257.399252 
+L 497.71785 260.940145 
+L 487.23594 260.940145 
+L 487.23594 260.940145 
+L 476.75403 260.940145 
+L 476.75403 260.940145 
+L 466.27212 260.940145 
+L 466.27212 260.940145 
+L 455.79021 260.940145 
+L 455.79021 260.940145 
+L 445.3083 260.940145 
+L 445.3083 260.940145 
+L 434.82639 260.940145 
+L 434.82639 260.940145 
+L 424.34448 260.940145 
+L 424.34448 260.940145 
+L 413.86257 260.940145 
+L 413.86257 260.940145 
+L 403.38066 260.940145 
+L 403.38066 260.940145 
+L 392.89875 260.940145 
+L 392.89875 260.940145 
+L 382.41684 260.940145 
+L 382.41684 260.940145 
+L 371.93493 260.940145 
+L 371.93493 260.940145 
+L 361.45302 260.940145 
+L 361.45302 260.940145 
+L 350.97111 260.940145 
+L 350.97111 260.940145 
+L 340.4892 260.940145 
+L 340.4892 260.940145 
+L 330.00729 260.940145 
+L 330.00729 260.940145 
+L 319.52538 260.940145 
+L 319.52538 260.940145 
+L 309.04347 260.940145 
+L 309.04347 260.940145 
+L 298.56156 260.940145 
+L 298.56156 260.940145 
+z
+" clip-path="url(#p241c8bdfae)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_52">
+    <!-- HISTOGRAM_TYPE.STEP_FILLED -->
+    <g transform="translate(322.461094 150.837891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-29" d="M 728 4666 
+L 3475 4666 
+L 3475 4134 
+L 1363 4134 
+L 1363 2759 
+L 3278 2759 
+L 3278 2228 
+L 1363 2228 
+L 1363 0 
+L 728 0 
+L 728 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-2b"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(1083.65625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(1143.859375 0)"/>
+     <use xlink:href="#DejaVuSansMono-29" transform="translate(1204.0625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(1264.265625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(1324.46875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(1384.671875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(1444.875 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(1505.078125 0)"/>
+    </g>
+   </g>
+   <g id="patch_54">
+    <path d="M 277.59774 260.940145 
+L 277.59774 156.837891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 277.59774 260.940145 
+L 508.19976 260.940145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_53">
+   <!-- Each series draws separately, so BAR_STACKED renders like BAR; STEP shows the edge only (recolored here from the theme's white). -->
+   <g transform="translate(7.2 286.00776) scale(0.085 -0.085)">
+    <defs>
+     <path id="DejaVuSans-Oblique-28" d="M 1081 4666 
+L 4031 4666 
+L 3928 4134 
+L 1606 4134 
+L 1338 2753 
+L 3566 2753 
+L 3463 2222 
+L 1234 2222 
+L 909 531 
+L 3284 531 
+L 3181 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5a" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5c" d="M 1588 -325 
+Q 1188 -997 936 -1164 
+Q 684 -1331 294 -1331 
+L -159 -1331 
+L -63 -850 
+L 269 -850 
+Q 509 -850 678 -719 
+Q 847 -588 1056 -206 
+L 1234 128 
+L 459 3500 
+L 1069 3500 
+L 1650 819 
+L 3256 3500 
+L 3859 3500 
+L 1588 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-f" d="M 575 794 
+L 1234 794 
+L 1131 256 
+L 422 -744 
+L 19 -744 
+L 469 256 
+L 575 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-25" d="M 1081 4666 
+L 2694 4666 
+Q 3350 4666 3675 4422 
+Q 4000 4178 4000 3688 
+Q 4000 3238 3720 2911 
+Q 3441 2584 2988 2516 
+Q 3375 2428 3569 2181 
+Q 3763 1934 3763 1522 
+Q 3763 819 3242 409 
+Q 2722 0 1819 0 
+L 172 0 
+L 1081 4666 
+z
+M 1234 2228 
+L 903 519 
+L 1919 519 
+Q 2491 519 2800 781 
+Q 3109 1044 3109 1522 
+Q 3109 1891 2904 2059 
+Q 2700 2228 2247 2228 
+L 1234 2228 
+z
+M 1606 4147 
+L 1331 2741 
+L 2272 2741 
+Q 2775 2741 3058 2959 
+Q 3341 3178 3341 3566 
+Q 3341 3869 3150 4008 
+Q 2959 4147 2541 4147 
+L 1606 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-24" d="M 2356 4666 
+L 3072 4666 
+L 3938 0 
+L 3278 0 
+L 3084 1197 
+L 984 1197 
+L 325 0 
+L -341 0 
+L 2356 4666 
+z
+M 2584 4044 
+L 1275 1722 
+L 2988 1722 
+L 2584 4044 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-35" d="M 1613 4147 
+L 1294 2491 
+L 2106 2491 
+Q 2584 2491 2879 2755 
+Q 3175 3019 3175 3444 
+Q 3175 3784 2976 3965 
+Q 2778 4147 2406 4147 
+L 1613 4147 
+z
+M 2772 2241 
+Q 2972 2194 3105 2009 
+Q 3238 1825 3413 1275 
+L 3809 0 
+L 3144 0 
+L 2778 1197 
+Q 2638 1659 2453 1815 
+Q 2269 1972 1888 1972 
+L 1191 1972 
+L 806 0 
+L 172 0 
+L 1081 4666 
+L 2503 4666 
+Q 3150 4666 3495 4373 
+Q 3841 4081 3841 3531 
+Q 3841 3044 3547 2687 
+Q 3253 2331 2772 2241 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-36" d="M 3859 4513 
+L 3738 3897 
+Q 3422 4066 3111 4152 
+Q 2800 4238 2509 4238 
+Q 1944 4238 1609 3991 
+Q 1275 3744 1275 3334 
+Q 1275 3109 1398 2989 
+Q 1522 2869 2034 2731 
+L 2413 2638 
+Q 3053 2472 3303 2217 
+Q 3553 1963 3553 1503 
+Q 3553 797 2998 353 
+Q 2444 -91 1538 -91 
+Q 1166 -91 791 -17 
+Q 416 56 38 206 
+L 166 856 
+Q 513 641 861 531 
+Q 1209 422 1556 422 
+Q 2147 422 2503 684 
+Q 2859 947 2859 1369 
+Q 2859 1650 2717 1795 
+Q 2575 1941 2106 2059 
+L 1728 2156 
+Q 1081 2325 845 2545 
+Q 609 2766 609 3163 
+Q 609 3859 1145 4304 
+Q 1681 4750 2541 4750 
+Q 2875 4750 3203 4690 
+Q 3531 4631 3859 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-37" d="M 378 4666 
+L 4325 4666 
+L 4225 4134 
+L 2559 4134 
+L 1759 0 
+L 1125 0 
+L 1925 4134 
+L 275 4134 
+L 378 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-26" d="M 4447 4306 
+L 4319 3641 
+Q 4019 3944 3683 4091 
+Q 3347 4238 2956 4238 
+Q 2422 4238 2017 3981 
+Q 1613 3725 1319 3200 
+Q 1131 2863 1032 2486 
+Q 934 2109 934 1728 
+Q 934 1091 1264 756 
+Q 1594 422 2222 422 
+Q 2656 422 3056 561 
+Q 3456 700 3834 978 
+L 3688 231 
+Q 3316 72 2936 -9 
+Q 2556 -91 2175 -91 
+Q 1278 -91 773 396 
+Q 269 884 269 1753 
+Q 269 2309 461 2846 
+Q 653 3384 1013 3828 
+Q 1394 4300 1883 4525 
+Q 2372 4750 3022 4750 
+Q 3422 4750 3780 4639 
+Q 4138 4528 4447 4306 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2e" d="M 1081 4666 
+L 1716 4666 
+L 1331 2700 
+L 3781 4666 
+L 4622 4666 
+L 1850 2438 
+L 3878 0 
+L 3109 0 
+L 1247 2272 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-27" d="M 1081 4666 
+L 2438 4666 
+Q 3519 4666 4070 4208 
+Q 4622 3750 4622 2847 
+Q 4622 2250 4412 1698 
+Q 4203 1147 3834 769 
+Q 3463 381 2891 190 
+Q 2319 0 1538 0 
+L 172 0 
+L 1081 4666 
+z
+M 1613 4147 
+L 909 519 
+L 1734 519 
+Q 2794 519 3375 1128 
+Q 3956 1738 3956 2847 
+Q 3956 3519 3581 3833 
+Q 3206 4147 2406 4147 
+L 1613 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4e" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-33" d="M 1081 4666 
+L 2541 4666 
+Q 3178 4666 3512 4369 
+Q 3847 4072 3847 3500 
+Q 3847 2731 3353 2303 
+Q 2859 1875 1966 1875 
+L 1172 1875 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+M 1613 4147 
+L 1275 2394 
+L 2069 2394 
+Q 2606 2394 2893 2669 
+Q 3181 2944 3181 3456 
+Q 3181 3784 2986 3965 
+Q 2791 4147 2438 4147 
+L 1613 4147 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-b" d="M 2731 4856 
+Q 1903 3822 1495 2892 
+Q 1088 1963 1088 1100 
+Q 1088 606 1206 120 
+Q 1325 -366 1563 -844 
+L 1063 -844 
+Q 775 -306 634 201 
+Q 494 709 494 1197 
+Q 494 2125 923 3036 
+Q 1353 3947 2222 4856 
+L 2731 4856 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-49" d="M 3059 4863 
+L 2969 4384 
+L 2419 4384 
+Q 2106 4384 1964 4261 
+Q 1822 4138 1753 3809 
+L 1691 3500 
+L 2638 3500 
+L 2553 3053 
+L 1606 3053 
+L 1013 0 
+L 434 0 
+L 1031 3053 
+L 481 3053 
+L 563 3500 
+L 1113 3500 
+L 1159 3744 
+Q 1278 4363 1576 4613 
+Q 1875 4863 2516 4863 
+L 3059 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-a" d="M 1147 4666 
+L 1147 2931 
+L 616 2931 
+L 616 4666 
+L 1147 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-c" d="M -397 -844 
+Q 434 191 840 1120 
+Q 1247 2050 1247 2913 
+Q 1247 3406 1130 3892 
+Q 1013 4378 775 4856 
+L 1275 4856 
+Q 1563 4316 1703 3812 
+Q 1844 3309 1844 2822 
+Q 1844 1891 1411 973 
+Q 978 56 116 -844 
+L -397 -844 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-11" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-28"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(63.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(124.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(179.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(242.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(274.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(326.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(388.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(429.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(457.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(518.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(570.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(602.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(666.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(707.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(768.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(850.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(902.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(934.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(986.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(1047.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1111.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1172.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1213.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(1274.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1314.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(1375.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(1403.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-f" transform="translate(1454.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1486.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1518.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1570.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1631.625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(1663.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(1732.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-35" transform="translate(1800.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(1869.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(1919.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-37" transform="translate(1983.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(2035.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-26" transform="translate(2103.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(2173.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(2239.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-27" transform="translate(2302.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2379.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2411.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2452.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(2513.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(2577.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2640.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2702.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2743.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2795.3125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(2827.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(2854.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4e" transform="translate(2882.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2940.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3002.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(3033.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(3102.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-35" transform="translate(3170.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(3240.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3274.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(3305.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-37" transform="translate(3369.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(3430.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-33" transform="translate(3493.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3553.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3585.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3637.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3701.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(3762.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3844.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3896.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3927.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3967.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4030.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4092.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4123.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(4185.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(4248.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4312.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4373.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4405.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(4466.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4530.25 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(4558.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4617.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-b" transform="translate(4649 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(4688.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4729.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(4790.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4845.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4906.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4934.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(4995.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5036.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(5098.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5161.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5193.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5257.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(5318.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5359.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5421.25 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-49" transform="translate(5453.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(5488.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(5529.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(5590.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5687.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(5719.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5758.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5822.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5883.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(5915.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5954.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(6018.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(6079.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(6177.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-a" transform="translate(6238.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(6266.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(6318.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(6350.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(6431.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(6495.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(6522.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(6562.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-c" transform="translate(6623.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(6662.703125 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pec819ca99d">
+   <rect x="25.59774" y="20.037891" width="230.60202" height="104.102254"/>
+  </clipPath>
+  <clipPath id="p40a75f714c">
+   <rect x="277.59774" y="20.037891" width="230.60202" height="104.102254"/>
+  </clipPath>
+  <clipPath id="p5faff61a36">
+   <rect x="25.59774" y="156.837891" width="230.60202" height="104.102254"/>
+  </clipPath>
+  <clipPath id="p241c8bdfae">
+   <rect x="277.59774" y="156.837891" width="230.60202" height="104.102254"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-histogram-type.svg
+++ b/docs/assets/imgs/const-histogram-type.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.431172pt" height="295.249752pt" viewBox="0 0 583.431172 295.249752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.431172pt" height="302.881752pt" viewBox="0 0 583.431172 302.881752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:34:25.560287</dc:date>
+    <dc:date>2026-08-23T23:46:43.284004</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,19 +21,19 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 295.249752 
-L 583.431172 295.249752 
-L 583.431172 0 
-L 0 0 
+   <path d="M 0 302.881752 
+L 583.431172 302.881752 
+L 583.431172 -0 
+L 0 -0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 25.59774 124.140145 
-L 256.19976 124.140145 
-L 256.19976 20.037891 
-L 25.59774 20.037891 
+    <path d="M 58.113326 124.140145 
+L 288.715346 124.140145 
+L 288.715346 20.037891 
+L 58.113326 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,17 +41,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="me33b082665" d="M 0 0 
+       <path id="m51763d152d" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#me33b082665" x="57.755191" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="90.270777" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- −2 -->
-      <g transform="translate(53.194566 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(85.710152 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-ef" d="M 3547 1894 
 L 3547 1369 
@@ -94,12 +94,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#me33b082665" x="96.006701" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="128.522287" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- −1 -->
-      <g transform="translate(91.446076 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(123.961662 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -121,12 +121,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#me33b082665" x="134.258211" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="166.773797" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 0 -->
-      <g transform="translate(132.033836 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(164.549422 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -157,12 +157,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#me33b082665" x="172.509721" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="205.025307" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 1 -->
-      <g transform="translate(170.285346 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(202.800932 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -170,12 +170,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#me33b082665" x="210.761231" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="243.276817" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 2 -->
-      <g transform="translate(208.536856 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(241.052442 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -183,12 +183,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#me33b082665" x="249.012741" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="281.528327" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 3 -->
-      <g transform="translate(246.788366 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(279.303952 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -233,41 +233,41 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 25.59774 124.140145 
-L 256.19976 124.140145 
-" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 124.140145 
+L 288.715346 124.140145 
+" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="mb57cb529fc" d="M 0 0 
+       <path id="m8d584bc601" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0 -->
-      <g transform="translate(14.64899 127.140145) scale(0.08 -0.08)">
+      <g transform="translate(47.164576 127.140145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 25.59774 106.43568 
-L 256.19976 106.43568 
-" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 106.43568 
+L 288.715346 106.43568 
+" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 10 -->
-      <g transform="translate(10.20024 109.43568) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 109.43568) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -275,18 +275,18 @@ L 256.19976 106.43568
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 25.59774 88.731215 
-L 256.19976 88.731215 
-" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 88.731215 
+L 288.715346 88.731215 
+" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 20 -->
-      <g transform="translate(10.20024 91.731215) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 91.731215) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -294,18 +294,18 @@ L 256.19976 88.731215
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 25.59774 71.02675 
-L 256.19976 71.02675 
-" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 71.02675 
+L 288.715346 71.02675 
+" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 30 -->
-      <g transform="translate(10.20024 74.02675) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 74.02675) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -313,18 +313,18 @@ L 256.19976 71.02675
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 25.59774 53.322285 
-L 256.19976 53.322285 
-" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 53.322285 
+L 288.715346 53.322285 
+" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 40 -->
-      <g transform="translate(10.20024 56.322285) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 56.322285) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -353,18 +353,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 25.59774 35.61782 
-L 256.19976 35.61782 
-" clip-path="url(#pec819ca99d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 35.61782 
+L 288.715346 35.61782 
+" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 50 -->
-      <g transform="translate(10.20024 38.61782) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 38.61782) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-18" d="M 791 1141 
 Q 847 659 1238 475 
@@ -400,168 +400,168 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 36.07965 124.140145 
-L 46.56156 124.140145 
-L 46.56156 120.599252 
-L 36.07965 120.599252 
+    <path d="M 68.595236 124.140145 
+L 79.077146 124.140145 
+L 79.077146 120.599252 
+L 68.595236 120.599252 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 46.56156 124.140145 
-L 57.04347 124.140145 
-L 57.04347 115.287912 
-L 46.56156 115.287912 
+    <path d="M 79.077146 124.140145 
+L 89.559056 124.140145 
+L 89.559056 115.287912 
+L 79.077146 115.287912 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 57.04347 124.140145 
-L 67.52538 124.140145 
-L 67.52538 115.287912 
-L 57.04347 115.287912 
+    <path d="M 89.559056 124.140145 
+L 100.040966 124.140145 
+L 100.040966 115.287912 
+L 89.559056 115.287912 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 67.52538 124.140145 
-L 78.00729 124.140145 
-L 78.00729 106.43568 
-L 67.52538 106.43568 
+    <path d="M 100.040966 124.140145 
+L 110.522876 124.140145 
+L 110.522876 106.43568 
+L 100.040966 106.43568 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 78.00729 124.140145 
-L 88.4892 124.140145 
-L 88.4892 88.731215 
-L 78.00729 88.731215 
+    <path d="M 110.522876 124.140145 
+L 121.004786 124.140145 
+L 121.004786 88.731215 
+L 110.522876 88.731215 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 88.4892 124.140145 
-L 98.97111 124.140145 
-L 98.97111 74.567643 
-L 88.4892 74.567643 
+    <path d="M 121.004786 124.140145 
+L 131.486696 124.140145 
+L 131.486696 74.567643 
+L 121.004786 74.567643 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 98.97111 124.140145 
-L 109.45302 124.140145 
-L 109.45302 63.944964 
-L 98.97111 63.944964 
+    <path d="M 131.486696 124.140145 
+L 141.968606 124.140145 
+L 141.968606 63.944964 
+L 131.486696 63.944964 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 109.45302 124.140145 
-L 119.93493 124.140145 
-L 119.93493 63.944964 
-L 109.45302 63.944964 
+    <path d="M 141.968606 124.140145 
+L 152.450516 124.140145 
+L 152.450516 63.944964 
+L 141.968606 63.944964 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 119.93493 124.140145 
-L 130.41684 124.140145 
-L 130.41684 40.929159 
-L 119.93493 40.929159 
+    <path d="M 152.450516 124.140145 
+L 162.932426 124.140145 
+L 162.932426 40.929159 
+L 152.450516 40.929159 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 130.41684 124.140145 
-L 140.89875 124.140145 
-L 140.89875 51.551838 
-L 130.41684 51.551838 
+    <path d="M 162.932426 124.140145 
+L 173.414336 124.140145 
+L 173.414336 51.551838 
+L 162.932426 51.551838 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 140.89875 124.140145 
-L 151.38066 124.140145 
-L 151.38066 24.995141 
-L 140.89875 24.995141 
+    <path d="M 173.414336 124.140145 
+L 183.896246 124.140145 
+L 183.896246 24.995141 
+L 173.414336 24.995141 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 151.38066 124.140145 
-L 161.86257 124.140145 
-L 161.86257 67.485857 
-L 151.38066 67.485857 
+    <path d="M 183.896246 124.140145 
+L 194.378156 124.140145 
+L 194.378156 67.485857 
+L 183.896246 67.485857 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 161.86257 124.140145 
-L 172.34448 124.140145 
-L 172.34448 67.485857 
-L 161.86257 67.485857 
+    <path d="M 194.378156 124.140145 
+L 204.860066 124.140145 
+L 204.860066 67.485857 
+L 194.378156 67.485857 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 172.34448 124.140145 
-L 182.82639 124.140145 
-L 182.82639 99.353894 
-L 172.34448 99.353894 
+    <path d="M 204.860066 124.140145 
+L 215.341976 124.140145 
+L 215.341976 99.353894 
+L 204.860066 99.353894 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 182.82639 124.140145 
-L 193.3083 124.140145 
-L 193.3083 95.813001 
-L 182.82639 95.813001 
+    <path d="M 215.341976 124.140145 
+L 225.823886 124.140145 
+L 225.823886 95.813001 
+L 215.341976 95.813001 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 193.3083 124.140145 
-L 203.79021 124.140145 
-L 203.79021 102.894787 
-L 193.3083 102.894787 
+    <path d="M 225.823886 124.140145 
+L 236.305796 124.140145 
+L 236.305796 102.894787 
+L 225.823886 102.894787 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 203.79021 124.140145 
-L 214.27212 124.140145 
-L 214.27212 117.058359 
-L 203.79021 117.058359 
+    <path d="M 236.305796 124.140145 
+L 246.787706 124.140145 
+L 246.787706 117.058359 
+L 236.305796 117.058359 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 214.27212 124.140145 
-L 224.75403 124.140145 
-L 224.75403 115.287912 
-L 214.27212 115.287912 
+    <path d="M 246.787706 124.140145 
+L 257.269616 124.140145 
+L 257.269616 115.287912 
+L 246.787706 115.287912 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 224.75403 124.140145 
-L 235.23594 124.140145 
-L 235.23594 122.369698 
-L 224.75403 122.369698 
+    <path d="M 257.269616 124.140145 
+L 267.751526 124.140145 
+L 267.751526 122.369698 
+L 257.269616 122.369698 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 235.23594 124.140145 
-L 245.71785 124.140145 
-L 245.71785 120.599252 
-L 235.23594 120.599252 
+    <path d="M 267.751526 124.140145 
+L 278.233436 124.140145 
+L 278.233436 120.599252 
+L 267.751526 120.599252 
 z
-" clip-path="url(#pec819ca99d)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="text_13">
     <!-- HISTOGRAM_TYPE.BAR -->
-    <g transform="translate(92.134219 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(124.649805 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-2b" d="M 428 4666 
 L 1063 4666 
@@ -857,22 +857,22 @@ z
     </g>
    </g>
    <g id="patch_23">
-    <path d="M 25.59774 124.140145 
-L 25.59774 20.037891 
+    <path d="M 58.113326 124.140145 
+L 58.113326 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_24">
-    <path d="M 25.59774 124.140145 
-L 256.19976 124.140145 
+    <path d="M 58.113326 124.140145 
+L 288.715346 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_25">
-    <path d="M 277.59774 124.140145 
-L 508.19976 124.140145 
-L 508.19976 20.037891 
-L 277.59774 20.037891 
+    <path d="M 310.113326 124.140145 
+L 540.715346 124.140145 
+L 540.715346 20.037891 
+L 310.113326 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -880,12 +880,12 @@ z
     <g id="xtick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#me33b082665" x="309.755191" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="342.270777" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- −2 -->
-      <g transform="translate(305.194566 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(337.710152 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
       </g>
@@ -894,12 +894,12 @@ z
     <g id="xtick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#me33b082665" x="348.006701" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="380.522287" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- −1 -->
-      <g transform="translate(343.446076 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(375.961662 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
       </g>
@@ -908,12 +908,12 @@ z
     <g id="xtick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#me33b082665" x="386.258211" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="418.773797" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 0 -->
-      <g transform="translate(384.033836 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(416.549422 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -921,12 +921,12 @@ z
     <g id="xtick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#me33b082665" x="424.509721" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="457.025307" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 1 -->
-      <g transform="translate(422.285346 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(454.800932 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -934,12 +934,12 @@ z
     <g id="xtick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#me33b082665" x="462.761231" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="495.276817" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- 2 -->
-      <g transform="translate(460.536856 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(493.052442 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -947,12 +947,12 @@ z
     <g id="xtick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#me33b082665" x="501.012741" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="533.528327" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
       <!-- 3 -->
-      <g transform="translate(498.788366 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(531.303952 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -961,36 +961,36 @@ z
    <g id="matplotlib.axis_4">
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 277.59774 124.140145 
-L 508.19976 124.140145 
-" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 124.140145 
+L 540.715346 124.140145 
+" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- 0 -->
-      <g transform="translate(266.64899 127.140145) scale(0.08 -0.08)">
+      <g transform="translate(299.164576 127.140145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 277.59774 106.43568 
-L 508.19976 106.43568 
-" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 106.43568 
+L 540.715346 106.43568 
+" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 10 -->
-      <g transform="translate(262.20024 109.43568) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 109.43568) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -998,18 +998,18 @@ L 508.19976 106.43568
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 277.59774 88.731215 
-L 508.19976 88.731215 
-" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 88.731215 
+L 540.715346 88.731215 
+" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 20 -->
-      <g transform="translate(262.20024 91.731215) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 91.731215) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1017,18 +1017,18 @@ L 508.19976 88.731215
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 277.59774 71.02675 
-L 508.19976 71.02675 
-" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 71.02675 
+L 540.715346 71.02675 
+" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 30 -->
-      <g transform="translate(262.20024 74.02675) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 74.02675) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1036,18 +1036,18 @@ L 508.19976 71.02675
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 277.59774 53.322285 
-L 508.19976 53.322285 
-" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 53.322285 
+L 540.715346 53.322285 
+" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 40 -->
-      <g transform="translate(262.20024 56.322285) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 56.322285) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1055,18 +1055,18 @@ L 508.19976 53.322285
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 277.59774 35.61782 
-L 508.19976 35.61782 
-" clip-path="url(#p40a75f714c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 35.61782 
+L 540.715346 35.61782 
+" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
       <!-- 50 -->
-      <g transform="translate(262.20024 38.61782) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 38.61782) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1074,168 +1074,168 @@ L 508.19976 35.61782
     </g>
    </g>
    <g id="patch_26">
-    <path d="M 288.07965 124.140145 
-L 298.56156 124.140145 
-L 298.56156 120.599252 
-L 288.07965 120.599252 
+    <path d="M 320.595236 124.140145 
+L 331.077146 124.140145 
+L 331.077146 120.599252 
+L 320.595236 120.599252 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_27">
-    <path d="M 298.56156 124.140145 
-L 309.04347 124.140145 
-L 309.04347 115.287912 
-L 298.56156 115.287912 
+    <path d="M 331.077146 124.140145 
+L 341.559056 124.140145 
+L 341.559056 115.287912 
+L 331.077146 115.287912 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_28">
-    <path d="M 309.04347 124.140145 
-L 319.52538 124.140145 
-L 319.52538 115.287912 
-L 309.04347 115.287912 
+    <path d="M 341.559056 124.140145 
+L 352.040966 124.140145 
+L 352.040966 115.287912 
+L 341.559056 115.287912 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_29">
-    <path d="M 319.52538 124.140145 
-L 330.00729 124.140145 
-L 330.00729 106.43568 
-L 319.52538 106.43568 
+    <path d="M 352.040966 124.140145 
+L 362.522876 124.140145 
+L 362.522876 106.43568 
+L 352.040966 106.43568 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_30">
-    <path d="M 330.00729 124.140145 
-L 340.4892 124.140145 
-L 340.4892 88.731215 
-L 330.00729 88.731215 
+    <path d="M 362.522876 124.140145 
+L 373.004786 124.140145 
+L 373.004786 88.731215 
+L 362.522876 88.731215 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_31">
-    <path d="M 340.4892 124.140145 
-L 350.97111 124.140145 
-L 350.97111 74.567643 
-L 340.4892 74.567643 
+    <path d="M 373.004786 124.140145 
+L 383.486696 124.140145 
+L 383.486696 74.567643 
+L 373.004786 74.567643 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_32">
-    <path d="M 350.97111 124.140145 
-L 361.45302 124.140145 
-L 361.45302 63.944964 
-L 350.97111 63.944964 
+    <path d="M 383.486696 124.140145 
+L 393.968606 124.140145 
+L 393.968606 63.944964 
+L 383.486696 63.944964 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_33">
-    <path d="M 361.45302 124.140145 
-L 371.93493 124.140145 
-L 371.93493 63.944964 
-L 361.45302 63.944964 
+    <path d="M 393.968606 124.140145 
+L 404.450516 124.140145 
+L 404.450516 63.944964 
+L 393.968606 63.944964 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_34">
-    <path d="M 371.93493 124.140145 
-L 382.41684 124.140145 
-L 382.41684 40.929159 
-L 371.93493 40.929159 
+    <path d="M 404.450516 124.140145 
+L 414.932426 124.140145 
+L 414.932426 40.929159 
+L 404.450516 40.929159 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_35">
-    <path d="M 382.41684 124.140145 
-L 392.89875 124.140145 
-L 392.89875 51.551838 
-L 382.41684 51.551838 
+    <path d="M 414.932426 124.140145 
+L 425.414336 124.140145 
+L 425.414336 51.551838 
+L 414.932426 51.551838 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_36">
-    <path d="M 392.89875 124.140145 
-L 403.38066 124.140145 
-L 403.38066 24.995141 
-L 392.89875 24.995141 
+    <path d="M 425.414336 124.140145 
+L 435.896246 124.140145 
+L 435.896246 24.995141 
+L 425.414336 24.995141 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_37">
-    <path d="M 403.38066 124.140145 
-L 413.86257 124.140145 
-L 413.86257 67.485857 
-L 403.38066 67.485857 
+    <path d="M 435.896246 124.140145 
+L 446.378156 124.140145 
+L 446.378156 67.485857 
+L 435.896246 67.485857 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_38">
-    <path d="M 413.86257 124.140145 
-L 424.34448 124.140145 
-L 424.34448 67.485857 
-L 413.86257 67.485857 
+    <path d="M 446.378156 124.140145 
+L 456.860066 124.140145 
+L 456.860066 67.485857 
+L 446.378156 67.485857 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_39">
-    <path d="M 424.34448 124.140145 
-L 434.82639 124.140145 
-L 434.82639 99.353894 
-L 424.34448 99.353894 
+    <path d="M 456.860066 124.140145 
+L 467.341976 124.140145 
+L 467.341976 99.353894 
+L 456.860066 99.353894 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_40">
-    <path d="M 434.82639 124.140145 
-L 445.3083 124.140145 
-L 445.3083 95.813001 
-L 434.82639 95.813001 
+    <path d="M 467.341976 124.140145 
+L 477.823886 124.140145 
+L 477.823886 95.813001 
+L 467.341976 95.813001 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_41">
-    <path d="M 445.3083 124.140145 
-L 455.79021 124.140145 
-L 455.79021 102.894787 
-L 445.3083 102.894787 
+    <path d="M 477.823886 124.140145 
+L 488.305796 124.140145 
+L 488.305796 102.894787 
+L 477.823886 102.894787 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_42">
-    <path d="M 455.79021 124.140145 
-L 466.27212 124.140145 
-L 466.27212 117.058359 
-L 455.79021 117.058359 
+    <path d="M 488.305796 124.140145 
+L 498.787706 124.140145 
+L 498.787706 117.058359 
+L 488.305796 117.058359 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_43">
-    <path d="M 466.27212 124.140145 
-L 476.75403 124.140145 
-L 476.75403 115.287912 
-L 466.27212 115.287912 
+    <path d="M 498.787706 124.140145 
+L 509.269616 124.140145 
+L 509.269616 115.287912 
+L 498.787706 115.287912 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_44">
-    <path d="M 476.75403 124.140145 
-L 487.23594 124.140145 
-L 487.23594 122.369698 
-L 476.75403 122.369698 
+    <path d="M 509.269616 124.140145 
+L 519.751526 124.140145 
+L 519.751526 122.369698 
+L 509.269616 122.369698 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_45">
-    <path d="M 487.23594 124.140145 
-L 497.71785 124.140145 
-L 497.71785 120.599252 
-L 487.23594 120.599252 
+    <path d="M 519.751526 124.140145 
+L 530.233436 124.140145 
+L 530.233436 120.599252 
+L 519.751526 120.599252 
 z
-" clip-path="url(#p40a75f714c)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="text_26">
     <!-- HISTOGRAM_TYPE.BAR_STACKED -->
-    <g transform="translate(322.461094 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(354.97668 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-26" d="M 3353 166 
 Q 3113 38 2859 -26 
@@ -1322,22 +1322,22 @@ z
     </g>
    </g>
    <g id="patch_46">
-    <path d="M 277.59774 124.140145 
-L 277.59774 20.037891 
+    <path d="M 310.113326 124.140145 
+L 310.113326 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_47">
-    <path d="M 277.59774 124.140145 
-L 508.19976 124.140145 
+    <path d="M 310.113326 124.140145 
+L 540.715346 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_3">
    <g id="patch_48">
-    <path d="M 25.59774 260.940145 
-L 256.19976 260.940145 
-L 256.19976 156.837891 
-L 25.59774 156.837891 
+    <path d="M 58.113326 260.940145 
+L 288.715346 260.940145 
+L 288.715346 156.837891 
+L 58.113326 156.837891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -1345,12 +1345,12 @@ z
     <g id="xtick_13">
      <g id="line2d_37">
       <g>
-       <use xlink:href="#me33b082665" x="57.755191" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="90.270777" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
       <!-- −2 -->
-      <g transform="translate(53.194566 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(85.710152 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
       </g>
@@ -1359,12 +1359,12 @@ z
     <g id="xtick_14">
      <g id="line2d_38">
       <g>
-       <use xlink:href="#me33b082665" x="96.006701" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="128.522287" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_28">
       <!-- −1 -->
-      <g transform="translate(91.446076 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(123.961662 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
       </g>
@@ -1373,12 +1373,12 @@ z
     <g id="xtick_15">
      <g id="line2d_39">
       <g>
-       <use xlink:href="#me33b082665" x="134.258211" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="166.773797" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_29">
       <!-- 0 -->
-      <g transform="translate(132.033836 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(164.549422 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -1386,12 +1386,12 @@ z
     <g id="xtick_16">
      <g id="line2d_40">
       <g>
-       <use xlink:href="#me33b082665" x="172.509721" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="205.025307" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_30">
       <!-- 1 -->
-      <g transform="translate(170.285346 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(202.800932 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -1399,12 +1399,12 @@ z
     <g id="xtick_17">
      <g id="line2d_41">
       <g>
-       <use xlink:href="#me33b082665" x="210.761231" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="243.276817" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
       <!-- 2 -->
-      <g transform="translate(208.536856 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(241.052442 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -1412,12 +1412,12 @@ z
     <g id="xtick_18">
      <g id="line2d_42">
       <g>
-       <use xlink:href="#me33b082665" x="249.012741" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="281.528327" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_32">
       <!-- 3 -->
-      <g transform="translate(246.788366 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(279.303952 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -1426,36 +1426,36 @@ z
    <g id="matplotlib.axis_6">
     <g id="ytick_13">
      <g id="line2d_43">
-      <path d="M 25.59774 260.940145 
-L 256.19976 260.940145 
-" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 260.940145 
+L 288.715346 260.940145 
+" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_44">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
       <!-- 0 -->
-      <g transform="translate(14.64899 263.940145) scale(0.08 -0.08)">
+      <g transform="translate(47.164576 263.940145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_45">
-      <path d="M 25.59774 243.23568 
-L 256.19976 243.23568 
-" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 243.23568 
+L 288.715346 243.23568 
+" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_46">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
       <!-- 10 -->
-      <g transform="translate(10.20024 246.23568) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 246.23568) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1463,18 +1463,18 @@ L 256.19976 243.23568
     </g>
     <g id="ytick_15">
      <g id="line2d_47">
-      <path d="M 25.59774 225.531215 
-L 256.19976 225.531215 
-" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 225.531215 
+L 288.715346 225.531215 
+" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_48">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
       <!-- 20 -->
-      <g transform="translate(10.20024 228.531215) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 228.531215) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1482,18 +1482,18 @@ L 256.19976 225.531215
     </g>
     <g id="ytick_16">
      <g id="line2d_49">
-      <path d="M 25.59774 207.82675 
-L 256.19976 207.82675 
-" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 207.82675 
+L 288.715346 207.82675 
+" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_50">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_36">
       <!-- 30 -->
-      <g transform="translate(10.20024 210.82675) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 210.82675) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1501,18 +1501,18 @@ L 256.19976 207.82675
     </g>
     <g id="ytick_17">
      <g id="line2d_51">
-      <path d="M 25.59774 190.122285 
-L 256.19976 190.122285 
-" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 190.122285 
+L 288.715346 190.122285 
+" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_52">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_37">
       <!-- 40 -->
-      <g transform="translate(10.20024 193.122285) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 193.122285) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1520,18 +1520,18 @@ L 256.19976 190.122285
     </g>
     <g id="ytick_18">
      <g id="line2d_53">
-      <path d="M 25.59774 172.41782 
-L 256.19976 172.41782 
-" clip-path="url(#p5faff61a36)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 58.113326 172.41782 
+L 288.715346 172.41782 
+" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_54">
       <g>
-       <use xlink:href="#mb57cb529fc" x="25.59774" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="58.113326" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_38">
       <!-- 50 -->
-      <g transform="translate(10.20024 175.41782) scale(0.08 -0.08)">
+      <g transform="translate(42.715826 175.41782) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1539,53 +1539,53 @@ L 256.19976 172.41782
     </g>
    </g>
    <g id="patch_49">
-    <path d="M 36.07965 260.940145 
-L 36.07965 257.399252 
-L 46.56156 257.399252 
-L 46.56156 252.087912 
-L 57.04347 252.087912 
-L 57.04347 252.087912 
-L 67.52538 252.087912 
-L 67.52538 243.23568 
-L 78.00729 243.23568 
-L 78.00729 225.531215 
-L 88.4892 225.531215 
-L 88.4892 211.367643 
-L 98.97111 211.367643 
-L 98.97111 200.744964 
-L 109.45302 200.744964 
-L 109.45302 200.744964 
-L 119.93493 200.744964 
-L 119.93493 177.729159 
-L 130.41684 177.729159 
-L 130.41684 188.351838 
-L 140.89875 188.351838 
-L 140.89875 161.795141 
-L 151.38066 161.795141 
-L 151.38066 204.285857 
-L 161.86257 204.285857 
-L 161.86257 204.285857 
-L 172.34448 204.285857 
-L 172.34448 236.153894 
-L 182.82639 236.153894 
-L 182.82639 232.613001 
-L 193.3083 232.613001 
-L 193.3083 239.694787 
-L 203.79021 239.694787 
-L 203.79021 253.858359 
-L 214.27212 253.858359 
-L 214.27212 252.087912 
-L 224.75403 252.087912 
-L 224.75403 259.169698 
-L 235.23594 259.169698 
-L 235.23594 257.399252 
-L 245.71785 257.399252 
-L 245.71785 260.940145 
-" clip-path="url(#p5faff61a36)" style="fill: none; opacity: 0.9; stroke: #08306b; stroke-width: 1.2; stroke-linejoin: miter"/>
+    <path d="M 68.595236 260.940145 
+L 68.595236 257.399252 
+L 79.077146 257.399252 
+L 79.077146 252.087912 
+L 89.559056 252.087912 
+L 89.559056 252.087912 
+L 100.040966 252.087912 
+L 100.040966 243.23568 
+L 110.522876 243.23568 
+L 110.522876 225.531215 
+L 121.004786 225.531215 
+L 121.004786 211.367643 
+L 131.486696 211.367643 
+L 131.486696 200.744964 
+L 141.968606 200.744964 
+L 141.968606 200.744964 
+L 152.450516 200.744964 
+L 152.450516 177.729159 
+L 162.932426 177.729159 
+L 162.932426 188.351838 
+L 173.414336 188.351838 
+L 173.414336 161.795141 
+L 183.896246 161.795141 
+L 183.896246 204.285857 
+L 194.378156 204.285857 
+L 194.378156 204.285857 
+L 204.860066 204.285857 
+L 204.860066 236.153894 
+L 215.341976 236.153894 
+L 215.341976 232.613001 
+L 225.823886 232.613001 
+L 225.823886 239.694787 
+L 236.305796 239.694787 
+L 236.305796 253.858359 
+L 246.787706 253.858359 
+L 246.787706 252.087912 
+L 257.269616 252.087912 
+L 257.269616 259.169698 
+L 267.751526 259.169698 
+L 267.751526 257.399252 
+L 278.233436 257.399252 
+L 278.233436 260.940145 
+" clip-path="url(#pe788ef890e)" style="fill: none; opacity: 0.9; stroke: #08306b; stroke-width: 1.2; stroke-linejoin: miter"/>
    </g>
    <g id="text_39">
     <!-- HISTOGRAM_TYPE.STEP -->
-    <g transform="translate(89.425078 150.837891) scale(0.09 -0.09)">
+    <g transform="translate(121.940664 150.837891) scale(0.09 -0.09)">
      <use xlink:href="#DejaVuSansMono-2b"/>
      <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
      <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
@@ -1608,22 +1608,22 @@ L 245.71785 260.940145
     </g>
    </g>
    <g id="patch_50">
-    <path d="M 25.59774 260.940145 
-L 25.59774 156.837891 
+    <path d="M 58.113326 260.940145 
+L 58.113326 156.837891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_51">
-    <path d="M 25.59774 260.940145 
-L 256.19976 260.940145 
+    <path d="M 58.113326 260.940145 
+L 288.715346 260.940145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_4">
    <g id="patch_52">
-    <path d="M 277.59774 260.940145 
-L 508.19976 260.940145 
-L 508.19976 156.837891 
-L 277.59774 156.837891 
+    <path d="M 310.113326 260.940145 
+L 540.715346 260.940145 
+L 540.715346 156.837891 
+L 310.113326 156.837891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -1631,12 +1631,12 @@ z
     <g id="xtick_19">
      <g id="line2d_55">
       <g>
-       <use xlink:href="#me33b082665" x="309.755191" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="342.270777" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_40">
       <!-- −2 -->
-      <g transform="translate(305.194566 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(337.710152 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
       </g>
@@ -1645,12 +1645,12 @@ z
     <g id="xtick_20">
      <g id="line2d_56">
       <g>
-       <use xlink:href="#me33b082665" x="348.006701" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="380.522287" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_41">
       <!-- −1 -->
-      <g transform="translate(343.446076 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(375.961662 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
       </g>
@@ -1659,12 +1659,12 @@ z
     <g id="xtick_21">
      <g id="line2d_57">
       <g>
-       <use xlink:href="#me33b082665" x="386.258211" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="418.773797" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_42">
       <!-- 0 -->
-      <g transform="translate(384.033836 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(416.549422 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -1672,12 +1672,12 @@ z
     <g id="xtick_22">
      <g id="line2d_58">
       <g>
-       <use xlink:href="#me33b082665" x="424.509721" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="457.025307" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_43">
       <!-- 1 -->
-      <g transform="translate(422.285346 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(454.800932 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -1685,12 +1685,12 @@ z
     <g id="xtick_23">
      <g id="line2d_59">
       <g>
-       <use xlink:href="#me33b082665" x="462.761231" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="495.276817" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_44">
       <!-- 2 -->
-      <g transform="translate(460.536856 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(493.052442 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -1698,12 +1698,12 @@ z
     <g id="xtick_24">
      <g id="line2d_60">
       <g>
-       <use xlink:href="#me33b082665" x="501.012741" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m51763d152d" x="533.528327" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_45">
       <!-- 3 -->
-      <g transform="translate(498.788366 273.440145) scale(0.08 -0.08)">
+      <g transform="translate(531.303952 273.440145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -1712,36 +1712,36 @@ z
    <g id="matplotlib.axis_8">
     <g id="ytick_19">
      <g id="line2d_61">
-      <path d="M 277.59774 260.940145 
-L 508.19976 260.940145 
-" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 260.940145 
+L 540.715346 260.940145 
+" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_62">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_46">
       <!-- 0 -->
-      <g transform="translate(266.64899 263.940145) scale(0.08 -0.08)">
+      <g transform="translate(299.164576 263.940145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_63">
-      <path d="M 277.59774 243.23568 
-L 508.19976 243.23568 
-" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 243.23568 
+L 540.715346 243.23568 
+" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_64">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_47">
       <!-- 10 -->
-      <g transform="translate(262.20024 246.23568) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 246.23568) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1749,18 +1749,18 @@ L 508.19976 243.23568
     </g>
     <g id="ytick_21">
      <g id="line2d_65">
-      <path d="M 277.59774 225.531215 
-L 508.19976 225.531215 
-" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 225.531215 
+L 540.715346 225.531215 
+" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_66">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_48">
       <!-- 20 -->
-      <g transform="translate(262.20024 228.531215) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 228.531215) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1768,18 +1768,18 @@ L 508.19976 225.531215
     </g>
     <g id="ytick_22">
      <g id="line2d_67">
-      <path d="M 277.59774 207.82675 
-L 508.19976 207.82675 
-" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 207.82675 
+L 540.715346 207.82675 
+" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_68">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_49">
       <!-- 30 -->
-      <g transform="translate(262.20024 210.82675) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 210.82675) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1787,18 +1787,18 @@ L 508.19976 207.82675
     </g>
     <g id="ytick_23">
      <g id="line2d_69">
-      <path d="M 277.59774 190.122285 
-L 508.19976 190.122285 
-" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 190.122285 
+L 540.715346 190.122285 
+" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_70">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_50">
       <!-- 40 -->
-      <g transform="translate(262.20024 193.122285) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 193.122285) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1806,18 +1806,18 @@ L 508.19976 190.122285
     </g>
     <g id="ytick_24">
      <g id="line2d_71">
-      <path d="M 277.59774 172.41782 
-L 508.19976 172.41782 
-" clip-path="url(#p241c8bdfae)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 310.113326 172.41782 
+L 540.715346 172.41782 
+" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_72">
       <g>
-       <use xlink:href="#mb57cb529fc" x="277.59774" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m8d584bc601" x="310.113326" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_51">
       <!-- 50 -->
-      <g transform="translate(262.20024 175.41782) scale(0.08 -0.08)">
+      <g transform="translate(294.715826 175.41782) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1825,92 +1825,92 @@ L 508.19976 172.41782
     </g>
    </g>
    <g id="patch_53">
-    <path d="M 288.07965 260.940145 
-L 288.07965 257.399252 
-L 298.56156 257.399252 
-L 298.56156 252.087912 
-L 309.04347 252.087912 
-L 309.04347 252.087912 
-L 319.52538 252.087912 
-L 319.52538 243.23568 
-L 330.00729 243.23568 
-L 330.00729 225.531215 
-L 340.4892 225.531215 
-L 340.4892 211.367643 
-L 350.97111 211.367643 
-L 350.97111 200.744964 
-L 361.45302 200.744964 
-L 361.45302 200.744964 
-L 371.93493 200.744964 
-L 371.93493 177.729159 
-L 382.41684 177.729159 
-L 382.41684 188.351838 
-L 392.89875 188.351838 
-L 392.89875 161.795141 
-L 403.38066 161.795141 
-L 403.38066 204.285857 
-L 413.86257 204.285857 
-L 413.86257 204.285857 
-L 424.34448 204.285857 
-L 424.34448 236.153894 
-L 434.82639 236.153894 
-L 434.82639 232.613001 
-L 445.3083 232.613001 
-L 445.3083 239.694787 
-L 455.79021 239.694787 
-L 455.79021 253.858359 
-L 466.27212 253.858359 
-L 466.27212 252.087912 
-L 476.75403 252.087912 
-L 476.75403 259.169698 
-L 487.23594 259.169698 
-L 487.23594 257.399252 
-L 497.71785 257.399252 
-L 497.71785 260.940145 
-L 487.23594 260.940145 
-L 487.23594 260.940145 
-L 476.75403 260.940145 
-L 476.75403 260.940145 
-L 466.27212 260.940145 
-L 466.27212 260.940145 
-L 455.79021 260.940145 
-L 455.79021 260.940145 
-L 445.3083 260.940145 
-L 445.3083 260.940145 
-L 434.82639 260.940145 
-L 434.82639 260.940145 
-L 424.34448 260.940145 
-L 424.34448 260.940145 
-L 413.86257 260.940145 
-L 413.86257 260.940145 
-L 403.38066 260.940145 
-L 403.38066 260.940145 
-L 392.89875 260.940145 
-L 392.89875 260.940145 
-L 382.41684 260.940145 
-L 382.41684 260.940145 
-L 371.93493 260.940145 
-L 371.93493 260.940145 
-L 361.45302 260.940145 
-L 361.45302 260.940145 
-L 350.97111 260.940145 
-L 350.97111 260.940145 
-L 340.4892 260.940145 
-L 340.4892 260.940145 
-L 330.00729 260.940145 
-L 330.00729 260.940145 
-L 319.52538 260.940145 
-L 319.52538 260.940145 
-L 309.04347 260.940145 
-L 309.04347 260.940145 
-L 298.56156 260.940145 
-L 298.56156 260.940145 
+    <path d="M 320.595236 260.940145 
+L 320.595236 257.399252 
+L 331.077146 257.399252 
+L 331.077146 252.087912 
+L 341.559056 252.087912 
+L 341.559056 252.087912 
+L 352.040966 252.087912 
+L 352.040966 243.23568 
+L 362.522876 243.23568 
+L 362.522876 225.531215 
+L 373.004786 225.531215 
+L 373.004786 211.367643 
+L 383.486696 211.367643 
+L 383.486696 200.744964 
+L 393.968606 200.744964 
+L 393.968606 200.744964 
+L 404.450516 200.744964 
+L 404.450516 177.729159 
+L 414.932426 177.729159 
+L 414.932426 188.351838 
+L 425.414336 188.351838 
+L 425.414336 161.795141 
+L 435.896246 161.795141 
+L 435.896246 204.285857 
+L 446.378156 204.285857 
+L 446.378156 204.285857 
+L 456.860066 204.285857 
+L 456.860066 236.153894 
+L 467.341976 236.153894 
+L 467.341976 232.613001 
+L 477.823886 232.613001 
+L 477.823886 239.694787 
+L 488.305796 239.694787 
+L 488.305796 253.858359 
+L 498.787706 253.858359 
+L 498.787706 252.087912 
+L 509.269616 252.087912 
+L 509.269616 259.169698 
+L 519.751526 259.169698 
+L 519.751526 257.399252 
+L 530.233436 257.399252 
+L 530.233436 260.940145 
+L 519.751526 260.940145 
+L 519.751526 260.940145 
+L 509.269616 260.940145 
+L 509.269616 260.940145 
+L 498.787706 260.940145 
+L 498.787706 260.940145 
+L 488.305796 260.940145 
+L 488.305796 260.940145 
+L 477.823886 260.940145 
+L 477.823886 260.940145 
+L 467.341976 260.940145 
+L 467.341976 260.940145 
+L 456.860066 260.940145 
+L 456.860066 260.940145 
+L 446.378156 260.940145 
+L 446.378156 260.940145 
+L 435.896246 260.940145 
+L 435.896246 260.940145 
+L 425.414336 260.940145 
+L 425.414336 260.940145 
+L 414.932426 260.940145 
+L 414.932426 260.940145 
+L 404.450516 260.940145 
+L 404.450516 260.940145 
+L 393.968606 260.940145 
+L 393.968606 260.940145 
+L 383.486696 260.940145 
+L 383.486696 260.940145 
+L 373.004786 260.940145 
+L 373.004786 260.940145 
+L 362.522876 260.940145 
+L 362.522876 260.940145 
+L 352.040966 260.940145 
+L 352.040966 260.940145 
+L 341.559056 260.940145 
+L 341.559056 260.940145 
+L 331.077146 260.940145 
+L 331.077146 260.940145 
 z
-" clip-path="url(#p241c8bdfae)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#pee49dd4bbf)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="text_52">
     <!-- HISTOGRAM_TYPE.STEP_FILLED -->
-    <g transform="translate(322.461094 150.837891) scale(0.09 -0.09)">
+    <g transform="translate(354.97668 150.837891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-29" d="M 728 4666 
 L 3475 4666 
@@ -1964,19 +1964,19 @@ z
     </g>
    </g>
    <g id="patch_54">
-    <path d="M 277.59774 260.940145 
-L 277.59774 156.837891 
+    <path d="M 310.113326 260.940145 
+L 310.113326 156.837891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_55">
-    <path d="M 277.59774 260.940145 
-L 508.19976 260.940145 
+    <path d="M 310.113326 260.940145 
+L 540.715346 260.940145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_53">
    <!-- Each series draws separately, so BAR_STACKED renders like BAR; STEP shows the edge only (recolored here from the theme's white). -->
-   <g transform="translate(7.2 286.00776) scale(0.085 -0.085)">
+   <g transform="translate(7.2 293.63976) scale(0.085 -0.085)">
     <defs>
      <path id="DejaVuSans-Oblique-28" d="M 1081 4666 
 L 4031 4666 
@@ -2863,17 +2863,17 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="pec819ca99d">
-   <rect x="25.59774" y="20.037891" width="230.60202" height="104.102254"/>
+  <clipPath id="pc63cb2a5b7">
+   <rect x="58.113326" y="20.037891" width="230.60202" height="104.102254"/>
   </clipPath>
-  <clipPath id="p40a75f714c">
-   <rect x="277.59774" y="20.037891" width="230.60202" height="104.102254"/>
+  <clipPath id="p31ecac502f">
+   <rect x="310.113326" y="20.037891" width="230.60202" height="104.102254"/>
   </clipPath>
-  <clipPath id="p5faff61a36">
-   <rect x="25.59774" y="156.837891" width="230.60202" height="104.102254"/>
+  <clipPath id="pe788ef890e">
+   <rect x="58.113326" y="156.837891" width="230.60202" height="104.102254"/>
   </clipPath>
-  <clipPath id="p241c8bdfae">
-   <rect x="277.59774" y="156.837891" width="230.60202" height="104.102254"/>
+  <clipPath id="pee49dd4bbf">
+   <rect x="310.113326" y="156.837891" width="230.60202" height="104.102254"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/imgs/const-normalize.svg
+++ b/docs/assets/imgs/const-normalize.svg
@@ -1,0 +1,1834 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="139.513752pt" viewBox="0 0 515.39976 139.513752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:26.040439</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 139.513752 
+L 515.39976 139.513752 
+L 515.39976 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 21.14899 109.740145 
+L 104.99976 109.740145 
+L 104.99976 20.037891 
+L 21.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p45a26820e3)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXjEAtxAvaClSIYiEn84iB8DzZrTeAUm1ve7eHl/XNM9vz2MVa4f3qdvvl4ezd98zB9kX8napCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokatD2frxMf2U8X/exwun8M33z63SZvulSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVoO37v0/9T97HmP3UsmL3u80ddapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQTfbNn90GwtG/yyYPSwYdalBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBoo6eX7oEIhYhObjyAAAAAElFTkSuQmCC" id="image10104a177c" transform="scale(1 -1) translate(0 -90)" x="20.88" y="-19.993752" width="84.24" height="90"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m7224594ec6" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m7224594ec6" x="31.630336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(29.405961 122.240145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m7224594ec6" x="73.555721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(71.331346 122.240145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_3">
+      <defs>
+       <path id="m12a04e2a40" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m12a04e2a40" x="21.14899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 0 -->
+      <g transform="translate(10.20024 34.250672) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="21.14899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1 -->
+      <g transform="translate(10.20024 56.676236) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="21.14899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 2 -->
+      <g transform="translate(10.20024 79.1018) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="21.14899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 3 -->
+      <g transform="translate(10.20024 101.527363) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="text_7">
+    <!-- NORMALIZE.LINEAR -->
+    <g transform="translate(19.728125 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-31" d="M 434 4666 
+L 1234 4666 
+L 2809 825 
+L 2809 4666 
+L 3419 4666 
+L 3419 0 
+L 2619 0 
+L 1044 3841 
+L 1044 0 
+L 434 0 
+L 434 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-30" d="M 269 4666 
+L 1113 4666 
+L 1919 2291 
+L 2731 4666 
+L 3578 4666 
+L 3578 0 
+L 2994 0 
+L 2994 4122 
+L 2163 1663 
+L 1684 1663 
+L 850 4122 
+L 850 0 
+L 269 0 
+L 269 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-3d" d="M 556 4666 
+L 3584 4666 
+L 3584 4184 
+L 1147 531 
+L 3653 531 
+L 3653 0 
+L 488 0 
+L 488 481 
+L 2859 4134 
+L 556 4134 
+L 556 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-31"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3d" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(903.046875 0)"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 21.14899 109.740145 
+L 21.14899 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 104.99976 109.740145 
+L 104.99976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 21.14899 109.740145 
+L 104.99976 109.740145 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 21.14899 20.037891 
+L 104.99976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_7">
+    <path d="M 121.94899 109.740145 
+L 205.79976 109.740145 
+L 205.79976 20.037891 
+L 121.94899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#paf37500bc2)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLKPuzOKizDAjQYSEJ+YNSIWoV34OGcBl4uD99ymNXN49NxGuy0P01L+Nmvx4/u3oZPXg1f5N+JGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGnT9cH83fHRzmKclbPe3wzd3u/FvdalBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGrR6ftkO/9XmZv6clvB+Hr/7evgavulSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNWs2X3+GfMp7m72kJx4/L8M3zAm91qUGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiTj1/ke4rc2FoenEAAAAASUVORK5CYII=" id="imagee41656276a" transform="scale(1 -1) translate(0 -90)" x="121.68" y="-19.993752" width="84.24" height="90"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_3">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m7224594ec6" x="132.430336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 0 -->
+      <g transform="translate(130.205961 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m7224594ec6" x="174.355721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 2 -->
+      <g transform="translate(172.131346 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_5">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="121.94899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0 -->
+      <g transform="translate(111.00024 34.250672) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="121.94899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 1 -->
+      <g transform="translate(111.00024 56.676236) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="121.94899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 2 -->
+      <g transform="translate(111.00024 79.1018) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="121.94899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 3 -->
+      <g transform="translate(111.00024 101.527363) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- NORMALIZE.LOG -->
+    <g transform="translate(128.655547 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-2a" d="M 3450 384 
+Q 3197 150 2880 29 
+Q 2563 -91 2194 -91 
+Q 1306 -91 812 545 
+Q 319 1181 319 2328 
+Q 319 3472 819 4111 
+Q 1319 4750 2209 4750 
+Q 2503 4750 2772 4667 
+Q 3041 4584 3291 4416 
+L 3291 3769 
+Q 3038 4009 2772 4123 
+Q 2506 4238 2209 4238 
+Q 1594 4238 1286 3761 
+Q 978 3284 978 2328 
+Q 978 1356 1276 889 
+Q 1575 422 2194 422 
+Q 2403 422 2561 470 
+Q 2719 519 2847 622 
+L 2847 1875 
+L 2169 1875 
+L 2169 2394 
+L 3450 2394 
+L 3450 384 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-31"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3d" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(722.4375 0)"/>
+    </g>
+   </g>
+   <g id="patch_8">
+    <path d="M 121.94899 109.740145 
+L 121.94899 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 205.79976 109.740145 
+L 205.79976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 121.94899 109.740145 
+L 205.79976 109.740145 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 121.94899 20.037891 
+L 205.79976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_12">
+    <path d="M 222.74899 109.740145 
+L 306.59976 109.740145 
+L 306.59976 20.037891 
+L 222.74899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p72c8654423)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXjEAtxAvaClSIYiEn84iB8DzZrTeAUm1ve7eHl/XNM9vz2MVa4f3qdvvl4ezd98zB9kX8napCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokatD2frxMf2U8X/exwun8M33z63SZvulSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVoO37v0/9T97HmP3UsmL3u80ddapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQTfbNn90GwtG/yyYPSwYdalBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBoo6eX7oEIhYhObjyAAAAAElFTkSuQmCC" id="imagef3f99986e3" transform="scale(1 -1) translate(0 -90)" x="222.48" y="-19.993752" width="84.24" height="90"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_5">
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m7224594ec6" x="233.230336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 0 -->
+      <g transform="translate(231.005961 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m7224594ec6" x="275.155721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 2 -->
+      <g transform="translate(272.931346 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_9">
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="222.74899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 0 -->
+      <g transform="translate(211.80024 34.250672) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="222.74899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 1 -->
+      <g transform="translate(211.80024 56.676236) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="222.74899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 2 -->
+      <g transform="translate(211.80024 79.1018) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="222.74899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- 3 -->
+      <g transform="translate(211.80024 101.527363) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- NORMALIZE.SYMLOG -->
+    <g transform="translate(221.328125 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-3c" d="M 116 4666 
+L 788 4666 
+L 1925 2606 
+L 3059 4666 
+L 3738 4666 
+L 2241 2094 
+L 2241 0 
+L 1606 0 
+L 1606 2094 
+L 116 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-31"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3d" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(903.046875 0)"/>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 222.74899 109.740145 
+L 222.74899 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 306.59976 109.740145 
+L 306.59976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 222.74899 109.740145 
+L 306.59976 109.740145 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 222.74899 20.037891 
+L 306.59976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_17">
+    <path d="M 323.54899 109.740145 
+L 407.39976 109.740145 
+L 407.39976 20.037891 
+L 323.54899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p9978290f8b)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML0NjABjQaEFH8wRnnifbgfbBZq4Ev2JzwLNf3+5cx2c3j89jC1e3D9M27i8vpm7vpi/w7UYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYOWp7fj9FfGw/dpbOHzMH/39eM4fdOlBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGrQ8v61Tv9PXcc6e/LPusHs6TR/1KUGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRp0vizzR5exweivDWbPdvNHXWqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqKPnByIxIxCMPttpAAAAAElFTkSuQmCC" id="image34b2ed6dec" transform="scale(1 -1) translate(0 -90)" x="323.28" y="-19.993752" width="84.24" height="90"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_7">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m7224594ec6" x="334.030336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 0 -->
+      <g transform="translate(331.805961 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m7224594ec6" x="375.955721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 2 -->
+      <g transform="translate(373.731346 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_13">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="323.54899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 0 -->
+      <g transform="translate(312.60024 34.250672) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="323.54899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 1 -->
+      <g transform="translate(312.60024 56.676236) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="323.54899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 2 -->
+      <g transform="translate(312.60024 79.1018) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="323.54899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 3 -->
+      <g transform="translate(312.60024 101.527363) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- NORMALIZE.ASINH -->
+    <g transform="translate(324.837266 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-2b" d="M 428 4666 
+L 1063 4666 
+L 1063 2753 
+L 2791 2753 
+L 2791 4666 
+L 3425 4666 
+L 3425 0 
+L 2791 0 
+L 2791 2222 
+L 1063 2222 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-31"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3d" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(842.84375 0)"/>
+    </g>
+   </g>
+   <g id="patch_18">
+    <path d="M 323.54899 109.740145 
+L 323.54899 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 407.39976 109.740145 
+L 407.39976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 323.54899 109.740145 
+L 407.39976 109.740145 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 323.54899 20.037891 
+L 407.39976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_5">
+   <g id="patch_22">
+    <path d="M 424.34899 109.740145 
+L 508.19976 109.740145 
+L 508.19976 20.037891 
+L 424.34899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g clip-path="url(#p0e06d644ee)">
+    <image xlink:href="data:image/png;base64,
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0KRJRBSgFQBQkO+BEYWyutQdAEzEqXcxp4wdVM9m0ur+5302DPb/O0hu12P3zz8fZm+ObJ8EX+nKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBm+u7h+GnjC+Hz2kNT4fj8M3X/fhNLzVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg04vzs+Gj87L17SGj2X8Xez74j6VX+D7DRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDdrMx+/dfzllnFfYXWPTSw0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0Sder5Ado4LSryFfTOAAAAAElFTkSuQmCC" id="imagefaa8d01eef" transform="scale(1 -1) translate(0 -90)" x="424.08" y="-19.993752" width="84.24" height="90"/>
+   </g>
+   <g id="matplotlib.axis_9">
+    <g id="xtick_9">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m7224594ec6" x="434.830336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 0 -->
+      <g transform="translate(432.605961 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m7224594ec6" x="476.755721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 2 -->
+      <g transform="translate(474.531346 122.240145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_10">
+    <g id="ytick_17">
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="424.34899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 0 -->
+      <g transform="translate(413.40024 34.250672) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="424.34899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 1 -->
+      <g transform="translate(413.40024 56.676236) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="424.34899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 2 -->
+      <g transform="translate(413.40024 79.1018) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m12a04e2a40" x="424.34899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 3 -->
+      <g transform="translate(413.40024 101.527363) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="text_35">
+    <!-- NORMALIZE.LOGIT -->
+    <g transform="translate(425.637266 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-31"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3d" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(842.84375 0)"/>
+    </g>
+   </g>
+   <g id="patch_23">
+    <path d="M 424.34899 109.740145 
+L 424.34899 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 508.19976 109.740145 
+L 508.19976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_25">
+    <path d="M 424.34899 109.740145 
+L 508.19976 109.740145 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_26">
+    <path d="M 424.34899 20.037891 
+L 508.19976 20.037891 
+" style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_36">
+   <!-- Same cell values under each norm; SYMLOG and ASINH also accept zero and negative values. -->
+   <g transform="translate(7.2 130.27176) scale(0.085 -0.085)">
+    <defs>
+     <path id="DejaVuSans-Oblique-36" d="M 3859 4513 
+L 3738 3897 
+Q 3422 4066 3111 4152 
+Q 2800 4238 2509 4238 
+Q 1944 4238 1609 3991 
+Q 1275 3744 1275 3334 
+Q 1275 3109 1398 2989 
+Q 1522 2869 2034 2731 
+L 2413 2638 
+Q 3053 2472 3303 2217 
+Q 3553 1963 3553 1503 
+Q 3553 797 2998 353 
+Q 2444 -91 1538 -91 
+Q 1166 -91 791 -17 
+Q 416 56 38 206 
+L 166 856 
+Q 513 641 861 531 
+Q 1209 422 1556 422 
+Q 2147 422 2503 684 
+Q 2859 947 2859 1369 
+Q 2859 1650 2717 1795 
+Q 2575 1941 2106 2059 
+L 1728 2156 
+Q 1081 2325 845 2545 
+Q 609 2766 609 3163 
+Q 609 3859 1145 4304 
+Q 1681 4750 2541 4750 
+Q 2875 4750 3203 4690 
+Q 3531 4631 3859 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-59" d="M 459 3500 
+L 1069 3500 
+L 1581 525 
+L 3256 3500 
+L 3866 3500 
+L 1875 0 
+L 1100 0 
+L 459 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-58" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3c" d="M 403 4666 
+L 1081 4666 
+L 1953 2747 
+L 3616 4666 
+L 4325 4666 
+L 2209 2222 
+L 1778 0 
+L 1147 0 
+L 1575 2222 
+L 403 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-30" d="M 1081 4666 
+L 2028 4666 
+L 2572 1522 
+L 4378 4666 
+L 5350 4666 
+L 4441 0 
+L 3828 0 
+L 4622 4091 
+L 2791 897 
+L 2175 897 
+L 1581 4103 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2f" d="M 1075 4666 
+L 1709 4666 
+L 909 525 
+L 3181 525 
+L 3078 0 
+L 172 0 
+L 1075 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-32" d="M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+M 2100 -91 
+Q 1241 -91 748 418 
+Q 256 928 256 1813 
+Q 256 2319 448 2847 
+Q 641 3375 978 3788 
+Q 1375 4272 1862 4511 
+Q 2350 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 2331 4593 1812 
+Q 4406 1294 4056 872 
+Q 3656 384 3173 146 
+Q 2691 -91 2100 -91 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2a" d="M 3494 697 
+L 3738 1919 
+L 2700 1919 
+L 2797 2438 
+L 4453 2438 
+L 4050 384 
+Q 3634 156 3143 32 
+Q 2653 -91 2156 -91 
+Q 1278 -91 783 396 
+Q 288 884 288 1753 
+Q 288 2475 589 3126 
+Q 891 3778 1422 4213 
+Q 1756 4484 2153 4617 
+Q 2550 4750 3034 4750 
+Q 3472 4750 3873 4639 
+Q 4275 4528 4641 4306 
+L 4513 3634 
+Q 4231 3928 3853 4083 
+Q 3475 4238 3047 4238 
+Q 2550 4238 2172 4048 
+Q 1794 3859 1497 3463 
+Q 1244 3125 1098 2667 
+Q 953 2209 953 1734 
+Q 953 1081 1287 751 
+Q 1622 422 2284 422 
+Q 2616 422 2925 492 
+Q 3234 563 3494 697 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-24" d="M 2356 4666 
+L 3072 4666 
+L 3938 0 
+L 3278 0 
+L 3084 1197 
+L 984 1197 
+L 325 0 
+L -341 0 
+L 2356 4666 
+z
+M 2584 4044 
+L 1275 1722 
+L 2988 1722 
+L 2584 4044 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2c" d="M 1081 4666 
+L 1716 4666 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-31" d="M 1081 4666 
+L 1931 4666 
+L 3219 666 
+L 4000 4666 
+L 4616 4666 
+L 3706 0 
+L 2853 0 
+L 1569 4025 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2b" d="M 1081 4666 
+L 1716 4666 
+L 1344 2753 
+L 3634 2753 
+L 4006 4666 
+L 4641 4666 
+L 3731 0 
+L 3097 0 
+L 3531 2222 
+L 1241 2222 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5d" d="M 744 3500 
+L 3475 3500 
+L 3372 2975 
+L 738 459 
+L 2913 459 
+L 2822 0 
+L -19 0 
+L 84 525 
+L 2719 3041 
+L 653 3041 
+L 744 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-11" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-36"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(124.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(222.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(283.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(315.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(370.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(432 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(459.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(487.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(519.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(578.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(639.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(667.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(730.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(792.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(844.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(876.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(939.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(1003.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1066.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1128.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1169.25 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1201.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1262.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(1323.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1378.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1442.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(1473.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1537.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1598.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(1639.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(1737.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1770.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(1802.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3c" transform="translate(1866.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-30" transform="translate(1927.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(2013.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-32" transform="translate(2066.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2a" transform="translate(2144.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2222.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2254 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(2315.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(2378.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2442.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(2473.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(2542.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2c" transform="translate(2605.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2635.3125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2b" transform="translate(2710.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2785.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2817.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(2878.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2906.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(2958.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3019.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(3051.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(3112.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(3167.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3222.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(3284.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3347.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3386.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5d" transform="translate(3418.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3470.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(3532.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3573.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3634.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(3666.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(3727.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(3791.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3854.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(3886.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3949.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(4011.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(4074.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(4136.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(4175.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(4203.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4262.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4323.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(4355.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(4414.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4476.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(4503.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4567.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(4628.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(4680.90625 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p45a26820e3">
+   <rect x="21.14899" y="20.037891" width="83.85077" height="89.702254"/>
+  </clipPath>
+  <clipPath id="paf37500bc2">
+   <rect x="121.94899" y="20.037891" width="83.85077" height="89.702254"/>
+  </clipPath>
+  <clipPath id="p72c8654423">
+   <rect x="222.74899" y="20.037891" width="83.85077" height="89.702254"/>
+  </clipPath>
+  <clipPath id="p9978290f8b">
+   <rect x="323.54899" y="20.037891" width="83.85077" height="89.702254"/>
+  </clipPath>
+  <clipPath id="p0e06d644ee">
+   <rect x="424.34899" y="20.037891" width="83.85077" height="89.702254"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-normalize.svg
+++ b/docs/assets/imgs/const-normalize.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="139.513752pt" viewBox="0 0 515.39976 139.513752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="151.681752pt" viewBox="0 0 512.39952 151.681752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:34:26.040439</dc:date>
+    <dc:date>2026-08-23T23:46:43.766671</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,41 +21,41 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 139.513752 
-L 515.39976 139.513752 
-L 515.39976 0 
+   <path d="M 0 151.681752 
+L 512.39952 151.681752 
+L 512.39952 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 21.14899 109.740145 
-L 104.99976 109.740145 
-L 104.99976 20.037891 
-L 21.14899 20.037891 
+    <path d="M 18.14875 109.740145 
+L 101.99952 109.740145 
+L 101.99952 20.037891 
+L 18.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p45a26820e3)">
+   <g clip-path="url(#pfb104c2cfe)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXjEAtxAvaClSIYiEn84iB8DzZrTeAUm1ve7eHl/XNM9vz2MVa4f3qdvvl4ezd98zB9kX8napCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokatD2frxMf2U8X/exwun8M33z63SZvulSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVoO37v0/9T97HmP3UsmL3u80ddapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQTfbNn90GwtG/yyYPSwYdalBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBoo6eX7oEIhYhObjyAAAAAElFTkSuQmCC" id="image10104a177c" transform="scale(1 -1) translate(0 -90)" x="20.88" y="-19.993752" width="84.24" height="90"/>
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkElEQVR4nO3bMUpDURRF0feC8x+DlZXjEAtxAvaClSIYiEn84iB8HzZrTeAUm1ve+fDy/jkWe377WD057p9exx4eb++Wbx6WL/LvRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA2a78fL8lfG83VbPTlO55+xh6/TZfmmSw0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUoHn83pb/p25j/X/q2GHyz3VbP+xSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNuplz/egcu4zu4rDDsEsNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEnX0/ALTRCIWy3NrSQAAAABJRU5ErkJggg==" id="imagef56119b402" transform="scale(1 -1) translate(0 -90)" x="18" y="-19.921752" width="84.24" height="90"/>
    </g>
    <g id="matplotlib.axis_1">
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m7224594ec6" d="M 0 0 
+       <path id="mb2f3784d5b" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m7224594ec6" x="31.630336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="28.630096" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0 -->
-      <g transform="translate(29.405961 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(26.405721 122.240145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -86,12 +86,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m7224594ec6" x="73.555721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="70.555481" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 2 -->
-      <g transform="translate(71.331346 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(68.331106 122.240145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-15" d="M 200 0 
 Q 231 578 439 1006 
@@ -128,17 +128,17 @@ z
     <g id="ytick_1">
      <g id="line2d_3">
       <defs>
-       <path id="m12a04e2a40" d="M 0 0 
+       <path id="m5f7c6cf3da" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m12a04e2a40" x="21.14899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="18.14875" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 0 -->
-      <g transform="translate(10.20024 34.250672) scale(0.08 -0.08)">
+      <g transform="translate(7.2 34.250672) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -146,12 +146,12 @@ L -3 0
     <g id="ytick_2">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m12a04e2a40" x="21.14899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="18.14875" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 1 -->
-      <g transform="translate(10.20024 56.676236) scale(0.08 -0.08)">
+      <g transform="translate(7.2 56.676236) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -172,12 +172,12 @@ z
     <g id="ytick_3">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m12a04e2a40" x="21.14899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="18.14875" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 2 -->
-      <g transform="translate(10.20024 79.1018) scale(0.08 -0.08)">
+      <g transform="translate(7.2 79.1018) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -185,12 +185,12 @@ z
     <g id="ytick_4">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m12a04e2a40" x="21.14899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="18.14875" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 3 -->
-      <g transform="translate(10.20024 101.527363) scale(0.08 -0.08)">
+      <g transform="translate(7.2 101.527363) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -234,7 +234,7 @@ z
    </g>
    <g id="text_7">
     <!-- NORMALIZE.LINEAR -->
-    <g transform="translate(19.728125 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(16.727885 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-31" d="M 434 4666 
 L 1234 4666 
@@ -409,49 +409,49 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 21.14899 109.740145 
-L 21.14899 20.037891 
+    <path d="M 18.14875 109.740145 
+L 18.14875 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 104.99976 109.740145 
-L 104.99976 20.037891 
+    <path d="M 101.99952 109.740145 
+L 101.99952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_5">
-    <path d="M 21.14899 109.740145 
-L 104.99976 109.740145 
+    <path d="M 18.14875 109.740145 
+L 101.99952 109.740145 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_6">
-    <path d="M 21.14899 20.037891 
-L 104.99976 20.037891 
+    <path d="M 18.14875 20.037891 
+L 101.99952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_7">
-    <path d="M 121.94899 109.740145 
-L 205.79976 109.740145 
-L 205.79976 20.037891 
-L 121.94899 20.037891 
+    <path d="M 118.94875 109.740145 
+L 202.79952 109.740145 
+L 202.79952 20.037891 
+L 118.94875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#paf37500bc2)">
+   <g clip-path="url(#pdf86bf24e1)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLKPuzOKizDAjQYSEJ+YNSIWoV34OGcBl4uD99ymNXN49NxGuy0P01L+Nmvx4/u3oZPXg1f5N+JGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGnT9cH83fHRzmKclbPe3wzd3u/FvdalBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGrR6ftkO/9XmZv6clvB+Hr/7evgavulSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNWs2X3+GfMp7m72kJx4/L8M3zAm91qUGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiTj1/ke4rc2FoenEAAAAASUVORK5CYII=" id="imagee41656276a" transform="scale(1 -1) translate(0 -90)" x="121.68" y="-19.993752" width="84.24" height="90"/>
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABnklEQVR4nO3dzUkDURiG0YnYg3s3FuLKPuzOKizDAlQMJCE/MGpExSK8Aw/nNPByefiWw6yu7h8O02DH3XH05PS9e50WsX0ZPnkxfJF/J2qQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGrQ5d3tzfDR9X4evrnZXU9L2G7Hv9WlBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGrQ6vFpM/xXm+v5Y/Tk9HYav/nnef85fNOlBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokatJrPP8M/ZTzOX6Mnp8P7eVrCaYG3utQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUaeeX7wiK3MWYYnBAAAAAElFTkSuQmCC" id="image298aec047c" transform="scale(1 -1) translate(0 -90)" x="118.8" y="-19.921752" width="84.24" height="90"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_3">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m7224594ec6" x="132.430336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="129.430096" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 0 -->
-      <g transform="translate(130.205961 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(127.205721 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -459,12 +459,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLK
     <g id="xtick_4">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m7224594ec6" x="174.355721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="171.355481" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 2 -->
-      <g transform="translate(172.131346 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(169.131106 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -474,12 +474,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLK
     <g id="ytick_5">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m12a04e2a40" x="121.94899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="118.94875" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 0 -->
-      <g transform="translate(111.00024 34.250672) scale(0.08 -0.08)">
+      <g transform="translate(108 34.250672) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -487,12 +487,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLK
     <g id="ytick_6">
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m12a04e2a40" x="121.94899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="118.94875" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 1 -->
-      <g transform="translate(111.00024 56.676236) scale(0.08 -0.08)">
+      <g transform="translate(108 56.676236) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -500,12 +500,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLK
     <g id="ytick_7">
      <g id="line2d_11">
       <g>
-       <use xlink:href="#m12a04e2a40" x="121.94899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="118.94875" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 2 -->
-      <g transform="translate(111.00024 79.1018) scale(0.08 -0.08)">
+      <g transform="translate(108 79.1018) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -513,12 +513,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLK
     <g id="ytick_8">
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m12a04e2a40" x="121.94899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="118.94875" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 3 -->
-      <g transform="translate(111.00024 101.527363) scale(0.08 -0.08)">
+      <g transform="translate(108 101.527363) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -526,7 +526,7 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmklEQVR4nO3dzUkDURiG0YnYg3s3FuLK
    </g>
    <g id="text_14">
     <!-- NORMALIZE.LOG -->
-    <g transform="translate(128.655547 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(125.655307 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-2a" d="M 3450 384 
 Q 3197 150 2880 29 
@@ -570,49 +570,49 @@ z
     </g>
    </g>
    <g id="patch_8">
-    <path d="M 121.94899 109.740145 
-L 121.94899 20.037891 
+    <path d="M 118.94875 109.740145 
+L 118.94875 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_9">
-    <path d="M 205.79976 109.740145 
-L 205.79976 20.037891 
+    <path d="M 202.79952 109.740145 
+L 202.79952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_10">
-    <path d="M 121.94899 109.740145 
-L 205.79976 109.740145 
+    <path d="M 118.94875 109.740145 
+L 202.79952 109.740145 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_11">
-    <path d="M 121.94899 20.037891 
-L 205.79976 20.037891 
+    <path d="M 118.94875 20.037891 
+L 202.79952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_3">
    <g id="patch_12">
-    <path d="M 222.74899 109.740145 
-L 306.59976 109.740145 
-L 306.59976 20.037891 
-L 222.74899 20.037891 
+    <path d="M 219.74875 109.740145 
+L 303.59952 109.740145 
+L 303.59952 20.037891 
+L 219.74875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p72c8654423)">
+   <g clip-path="url(#p02d6477a70)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXjEAtxAvaClSIYiEn84iB8DzZrTeAUm1ve7eHl/XNM9vz2MVa4f3qdvvl4ezd98zB9kX8napCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokatD2frxMf2U8X/exwun8M33z63SZvulSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVoO37v0/9T97HmP3UsmL3u80ddapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQTfbNn90GwtG/yyYPSwYdalBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBoo6eX7oEIhYhObjyAAAAAElFTkSuQmCC" id="imagef3f99986e3" transform="scale(1 -1) translate(0 -90)" x="222.48" y="-19.993752" width="84.24" height="90"/>
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkElEQVR4nO3bMUpDURRF0feC8x+DlZXjEAtxAvaClSIYiEn84iB8HzZrTeAUm1ve+fDy/jkWe377WD057p9exx4eb++Wbx6WL/LvRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA2a78fL8lfG83VbPTlO55+xh6/TZfmmSw0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUoHn83pb/p25j/X/q2GHyz3VbP+xSg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNuplz/egcu4zu4rDDsEsNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEnX0/ALTRCIWy3NrSQAAAABJRU5ErkJggg==" id="imagee6861d4435" transform="scale(1 -1) translate(0 -90)" x="219.6" y="-19.921752" width="84.24" height="90"/>
    </g>
    <g id="matplotlib.axis_5">
     <g id="xtick_5">
      <g id="line2d_13">
       <g>
-       <use xlink:href="#m7224594ec6" x="233.230336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="230.230096" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 0 -->
-      <g transform="translate(231.005961 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(228.005721 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -620,12 +620,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXj
     <g id="xtick_6">
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m7224594ec6" x="275.155721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="272.155481" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 2 -->
-      <g transform="translate(272.931346 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(269.931106 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -635,12 +635,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXj
     <g id="ytick_9">
      <g id="line2d_15">
       <g>
-       <use xlink:href="#m12a04e2a40" x="222.74899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="219.74875" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 0 -->
-      <g transform="translate(211.80024 34.250672) scale(0.08 -0.08)">
+      <g transform="translate(208.8 34.250672) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -648,12 +648,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXj
     <g id="ytick_10">
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m12a04e2a40" x="222.74899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="219.74875" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- 1 -->
-      <g transform="translate(211.80024 56.676236) scale(0.08 -0.08)">
+      <g transform="translate(208.8 56.676236) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -661,12 +661,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXj
     <g id="ytick_11">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m12a04e2a40" x="222.74899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="219.74875" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
       <!-- 2 -->
-      <g transform="translate(211.80024 79.1018) scale(0.08 -0.08)">
+      <g transform="translate(208.8 79.1018) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -674,12 +674,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXj
     <g id="ytick_12">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m12a04e2a40" x="222.74899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="219.74875" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- 3 -->
-      <g transform="translate(211.80024 101.527363) scale(0.08 -0.08)">
+      <g transform="translate(208.8 101.527363) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -687,7 +687,7 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABj0lEQVR4nO3bMUpDURRF0feD8x+DlZXj
    </g>
    <g id="text_21">
     <!-- NORMALIZE.SYMLOG -->
-    <g transform="translate(221.328125 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(218.327885 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-36" d="M 3163 4506 
 L 3163 3866 
@@ -752,49 +752,49 @@ z
     </g>
    </g>
    <g id="patch_13">
-    <path d="M 222.74899 109.740145 
-L 222.74899 20.037891 
+    <path d="M 219.74875 109.740145 
+L 219.74875 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_14">
-    <path d="M 306.59976 109.740145 
-L 306.59976 20.037891 
+    <path d="M 303.59952 109.740145 
+L 303.59952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_15">
-    <path d="M 222.74899 109.740145 
-L 306.59976 109.740145 
+    <path d="M 219.74875 109.740145 
+L 303.59952 109.740145 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_16">
-    <path d="M 222.74899 20.037891 
-L 306.59976 20.037891 
+    <path d="M 219.74875 20.037891 
+L 303.59952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_4">
    <g id="patch_17">
-    <path d="M 323.54899 109.740145 
-L 407.39976 109.740145 
-L 407.39976 20.037891 
-L 323.54899 20.037891 
+    <path d="M 320.54875 109.740145 
+L 404.39952 109.740145 
+L 404.39952 20.037891 
+L 320.54875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p9978290f8b)">
+   <g clip-path="url(#p9c95000203)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML0NjABjQaEFH8wRnnifbgfbBZq4Ev2JzwLNf3+5cx2c3j89jC1e3D9M27i8vpm7vpi/w7UYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYOWp7fj9FfGw/dpbOHzMH/39eM4fdOlBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGrQ8v61Tv9PXcc6e/LPusHs6TR/1KUGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRokapCoQaIGiRp0vizzR5exweivDWbPdvNHXWqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqKPnByIxIxCMPttpAAAAAElFTkSuQmCC" id="image34b2ed6dec" transform="scale(1 -1) translate(0 -90)" x="323.28" y="-19.993752" width="84.24" height="90"/>
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABk0lEQVR4nO3bvUlEURRG0ftG+29EE3ML0NjABjQaEFH8wRnfE+3BO7BZq4Ev2JzwLNf3+5cx2c3j8+zJcXX7ME7h7uJy+uZu+iL/TtQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNSg5entOP2V8fC9zp4cn4f5m79eP47TN11qkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogYt71/b9P/UbWyzJ8c2f/LPus4fdqlBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogadL8v80WWcZPQkznbzh11qkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKij5wc/aSMQrkbHVgAAAABJRU5ErkJggg==" id="imageaf7ccfdd79" transform="scale(1 -1) translate(0 -90)" x="320.4" y="-19.921752" width="84.24" height="90"/>
    </g>
    <g id="matplotlib.axis_7">
     <g id="xtick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m7224594ec6" x="334.030336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="331.030096" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 0 -->
-      <g transform="translate(331.805961 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(328.805721 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -802,12 +802,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML
     <g id="xtick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m7224594ec6" x="375.955721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="372.955481" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 2 -->
-      <g transform="translate(373.731346 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(370.731106 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -817,12 +817,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML
     <g id="ytick_13">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m12a04e2a40" x="323.54899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="320.54875" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 0 -->
-      <g transform="translate(312.60024 34.250672) scale(0.08 -0.08)">
+      <g transform="translate(309.6 34.250672) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -830,12 +830,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML
     <g id="ytick_14">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m12a04e2a40" x="323.54899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="320.54875" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
       <!-- 1 -->
-      <g transform="translate(312.60024 56.676236) scale(0.08 -0.08)">
+      <g transform="translate(309.6 56.676236) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -843,12 +843,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML
     <g id="ytick_15">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m12a04e2a40" x="323.54899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="320.54875" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
       <!-- 2 -->
-      <g transform="translate(312.60024 79.1018) scale(0.08 -0.08)">
+      <g transform="translate(309.6 79.1018) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -856,12 +856,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML
     <g id="ytick_16">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m12a04e2a40" x="323.54899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="320.54875" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
       <!-- 3 -->
-      <g transform="translate(312.60024 101.527363) scale(0.08 -0.08)">
+      <g transform="translate(309.6 101.527363) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -869,7 +869,7 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABkklEQVR4nO3bvUlEURRG0ftG+29EE3ML
    </g>
    <g id="text_28">
     <!-- NORMALIZE.ASINH -->
-    <g transform="translate(324.837266 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(321.837026 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-2b" d="M 428 4666 
 L 1063 4666 
@@ -905,49 +905,49 @@ z
     </g>
    </g>
    <g id="patch_18">
-    <path d="M 323.54899 109.740145 
-L 323.54899 20.037891 
+    <path d="M 320.54875 109.740145 
+L 320.54875 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_19">
-    <path d="M 407.39976 109.740145 
-L 407.39976 20.037891 
+    <path d="M 404.39952 109.740145 
+L 404.39952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_20">
-    <path d="M 323.54899 109.740145 
-L 407.39976 109.740145 
+    <path d="M 320.54875 109.740145 
+L 404.39952 109.740145 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_21">
-    <path d="M 323.54899 20.037891 
-L 407.39976 20.037891 
+    <path d="M 320.54875 20.037891 
+L 404.39952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_5">
    <g id="patch_22">
-    <path d="M 424.34899 109.740145 
-L 508.19976 109.740145 
-L 508.19976 20.037891 
-L 424.34899 20.037891 
+    <path d="M 421.34875 109.740145 
+L 505.19952 109.740145 
+L 505.19952 20.037891 
+L 421.34875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
-   <g clip-path="url(#p0e06d644ee)">
+   <g clip-path="url(#p796317b813)">
     <image xlink:href="data:image/png;base64,
-iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0KRJRBSgFQBQkO+BEYWyutQdAEzEqXcxp4wdVM9m0ur+5302DPb/O0hu12P3zz8fZm+ObJ8EX+nKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBogaJGiRqkKhBm+u7h+GnjC+Hz2kNT4fj8M3X/fhNLzVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg04vzs+Gj87L17SGj2X8Xez74j6VX+D7DRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDdrMx+/dfzllnFfYXWPTSw0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0Sder5Ado4LSryFfTOAAAAAElFTkSuQmCC" id="imagefaa8d01eef" transform="scale(1 -1) translate(0 -90)" x="424.08" y="-19.993752" width="84.24" height="90"/>
+iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABmElEQVR4nO3bvU0DQRhF0TWiAjIaoQ0KRJRBSgFQBYkd8CMwtlayQSB6gFnpck4DL7iayb7V5dX9dhrs6XUePTltNrtpCevbm+GbJ8MX+XOiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBokaJGqQqEGiBq2u7x6GnzI+7z9GT06P++O0hJfd+F0vNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDRA0SNUjUIFGDTi/Oz4aPzofP4Zvvh/E3sT/eDu5T+QW+3yBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1CBRg0QNEjVI1KDVfPza/odTxnmBzaV2vdQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUYNEDRI1SNQgUaeebwgXLSqkMDRAAAAAAElFTkSuQmCC" id="image57064732c2" transform="scale(1 -1) translate(0 -90)" x="421.2" y="-19.921752" width="84.24" height="90"/>
    </g>
    <g id="matplotlib.axis_9">
     <g id="xtick_9">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m7224594ec6" x="434.830336" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="431.830096" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_29">
       <!-- 0 -->
-      <g transform="translate(432.605961 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(429.605721 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -955,12 +955,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0K
     <g id="xtick_10">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m7224594ec6" x="476.755721" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mb2f3784d5b" x="473.755481" y="109.740145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_30">
       <!-- 2 -->
-      <g transform="translate(474.531346 122.240145) scale(0.08 -0.08)">
+      <g transform="translate(471.531106 122.240145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -970,12 +970,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0K
     <g id="ytick_17">
      <g id="line2d_27">
       <g>
-       <use xlink:href="#m12a04e2a40" x="424.34899" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="421.34875" y="31.250672" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
       <!-- 0 -->
-      <g transform="translate(413.40024 34.250672) scale(0.08 -0.08)">
+      <g transform="translate(410.4 34.250672) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -983,12 +983,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0K
     <g id="ytick_18">
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m12a04e2a40" x="424.34899" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="421.34875" y="53.676236" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_32">
       <!-- 1 -->
-      <g transform="translate(413.40024 56.676236) scale(0.08 -0.08)">
+      <g transform="translate(410.4 56.676236) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -996,12 +996,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0K
     <g id="ytick_19">
      <g id="line2d_29">
       <g>
-       <use xlink:href="#m12a04e2a40" x="424.34899" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="421.34875" y="76.1018" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
       <!-- 2 -->
-      <g transform="translate(413.40024 79.1018) scale(0.08 -0.08)">
+      <g transform="translate(410.4 79.1018) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -1009,12 +1009,12 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0K
     <g id="ytick_20">
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m12a04e2a40" x="424.34899" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5f7c6cf3da" x="421.34875" y="98.527363" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
       <!-- 3 -->
-      <g transform="translate(413.40024 101.527363) scale(0.08 -0.08)">
+      <g transform="translate(410.4 101.527363) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -1022,7 +1022,7 @@ iVBORw0KGgoAAAANSUhEUgAAAHUAAAB9CAYAAACcVyzRAAABlUlEQVR4nO3bvU0DQRhF0TWiAjIaoQ0K
    </g>
    <g id="text_35">
     <!-- NORMALIZE.LOGIT -->
-    <g transform="translate(425.637266 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(422.637026 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-37" d="M 147 4666 
 L 3706 4666 
@@ -1054,29 +1054,29 @@ z
     </g>
    </g>
    <g id="patch_23">
-    <path d="M 424.34899 109.740145 
-L 424.34899 20.037891 
+    <path d="M 421.34875 109.740145 
+L 421.34875 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_24">
-    <path d="M 508.19976 109.740145 
-L 508.19976 20.037891 
+    <path d="M 505.19952 109.740145 
+L 505.19952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_25">
-    <path d="M 424.34899 109.740145 
-L 508.19976 109.740145 
+    <path d="M 421.34875 109.740145 
+L 505.19952 109.740145 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_26">
-    <path d="M 424.34899 20.037891 
-L 508.19976 20.037891 
+    <path d="M 421.34875 20.037891 
+L 505.19952 20.037891 
 " style="fill: none; stroke: #333333; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_36">
    <!-- Same cell values under each norm; SYMLOG and ASINH also accept zero and negative values. -->
-   <g transform="translate(7.2 130.27176) scale(0.085 -0.085)">
+   <g transform="translate(55.910541 142.43976) scale(0.085 -0.085)">
     <defs>
      <path id="DejaVuSans-Oblique-36" d="M 3859 4513 
 L 3738 3897 
@@ -1815,20 +1815,20 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p45a26820e3">
-   <rect x="21.14899" y="20.037891" width="83.85077" height="89.702254"/>
+  <clipPath id="pfb104c2cfe">
+   <rect x="18.14875" y="20.037891" width="83.85077" height="89.702254"/>
   </clipPath>
-  <clipPath id="paf37500bc2">
-   <rect x="121.94899" y="20.037891" width="83.85077" height="89.702254"/>
+  <clipPath id="pdf86bf24e1">
+   <rect x="118.94875" y="20.037891" width="83.85077" height="89.702254"/>
   </clipPath>
-  <clipPath id="p72c8654423">
-   <rect x="222.74899" y="20.037891" width="83.85077" height="89.702254"/>
+  <clipPath id="p02d6477a70">
+   <rect x="219.74875" y="20.037891" width="83.85077" height="89.702254"/>
   </clipPath>
-  <clipPath id="p9978290f8b">
-   <rect x="323.54899" y="20.037891" width="83.85077" height="89.702254"/>
+  <clipPath id="p9c95000203">
+   <rect x="320.54875" y="20.037891" width="83.85077" height="89.702254"/>
   </clipPath>
-  <clipPath id="p0e06d644ee">
-   <rect x="424.34899" y="20.037891" width="83.85077" height="89.702254"/>
+  <clipPath id="p796317b813">
+   <rect x="421.34875" y="20.037891" width="83.85077" height="89.702254"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/imgs/const-orientation.svg
+++ b/docs/assets/imgs/const-orientation.svg
@@ -1,0 +1,1012 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="195.59952pt" viewBox="0 0 512.39952 195.59952" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:25.617687</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 195.59952 
+L 512.39952 195.59952 
+L 512.39952 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 18.14875 174.18452 
+L 252.535145 174.18452 
+L 252.535145 20.037891 
+L 18.14875 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m46d911fdbc" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m46d911fdbc" x="51.231997" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- w -->
+      <g transform="translate(48.343247 186.68452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5a" d="M 672 3347 
+L 1316 709 
+L 1969 3347 
+L 2600 3347 
+L 3256 725 
+L 3941 3347 
+L 4503 3347 
+L 3531 0 
+L 2947 0 
+L 2266 2591 
+L 1606 0 
+L 1022 0 
+L 56 3347 
+L 672 3347 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5a"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="107.305297" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- x -->
+      <g transform="translate(105.305297 186.68452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5b" d="M 94 3347 
+L 822 3347 
+L 1591 2169 
+L 2369 3347 
+L 3053 3331 
+L 1925 1716 
+L 3103 0 
+L 2384 0 
+L 1553 1256 
+L 747 0 
+L 34 0 
+L 1213 1716 
+L 94 3347 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5b"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="163.378598" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- y -->
+      <g transform="translate(161.378598 186.68452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5c" d="M 2503 3347 
+L 3125 3347 
+Q 3006 3025 2597 1878 
+Q 2291 1016 2084 472 
+Q 1597 -809 1397 -1090 
+Q 1197 -1372 709 -1372 
+Q 591 -1372 527 -1362 
+Q 463 -1353 369 -1328 
+L 369 -816 
+Q 516 -856 581 -865 
+Q 647 -875 697 -875 
+Q 853 -875 926 -823 
+Q 1000 -772 1050 -697 
+Q 1066 -672 1162 -440 
+Q 1259 -209 1303 -97 
+L 66 3347 
+L 703 3347 
+L 1600 622 
+L 2503 3347 
+z
+M 1597 3428 
+L 1597 3428 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5c"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="219.451898" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- z -->
+      <g transform="translate(217.451898 186.68452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-5d" d="M 163 444 
+L 2147 2844 
+L 309 2844 
+L 309 3347 
+L 2903 3347 
+L 2903 2888 
+L 931 503 
+L 2963 503 
+L 2963 0 
+L 163 0 
+L 163 444 
+z
+M 1609 3428 
+L 1609 3428 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-5d"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_5">
+      <path d="M 18.14875 174.18452 
+L 252.535145 174.18452 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_6">
+      <defs>
+       <path id="m8f77a8a4f2" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 0 -->
+      <g transform="translate(7.2 177.18452) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_7">
+      <path d="M 18.14875 149.716801 
+L 252.535145 149.716801 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="149.716801" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 1 -->
+      <g transform="translate(7.2 152.716801) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_9">
+      <path d="M 18.14875 125.249082 
+L 252.535145 125.249082 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="125.249082" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 2 -->
+      <g transform="translate(7.2 128.249082) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_11">
+      <path d="M 18.14875 100.781363 
+L 252.535145 100.781363 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="100.781363" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 3 -->
+      <g transform="translate(7.2 103.781363) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_13">
+      <path d="M 18.14875 76.313644 
+L 252.535145 76.313644 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="76.313644" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 4 -->
+      <g transform="translate(7.2 79.313644) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_15">
+      <path d="M 18.14875 51.845925 
+L 252.535145 51.845925 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="51.845925" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 5 -->
+      <g transform="translate(7.2 54.845925) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <path d="M 18.14875 27.378206 
+L 252.535145 27.378206 
+" clip-path="url(#p9305292673)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="18.14875" y="27.378206" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 6 -->
+      <g transform="translate(7.2 30.378206) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 28.802677 174.18452 
+L 73.661317 174.18452 
+L 73.661317 76.313644 
+L 28.802677 76.313644 
+z
+" clip-path="url(#p9305292673)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 84.875977 174.18452 
+L 129.734617 174.18452 
+L 129.734617 27.378206 
+L 84.875977 27.378206 
+z
+" clip-path="url(#p9305292673)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 140.949278 174.18452 
+L 185.807918 174.18452 
+L 185.807918 100.781363 
+L 140.949278 100.781363 
+z
+" clip-path="url(#p9305292673)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 197.022578 174.18452 
+L 241.881218 174.18452 
+L 241.881218 51.845925 
+L 197.022578 51.845925 
+z
+" clip-path="url(#p9305292673)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_12">
+    <!-- ORIENTATION.VERTICAL -->
+    <g transform="translate(81.159135 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-31" d="M 434 4666 
+L 1234 4666 
+L 2809 825 
+L 2809 4666 
+L 3419 4666 
+L 3419 0 
+L 2619 0 
+L 1044 3841 
+L 1044 0 
+L 434 0 
+L 434 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-39" d="M 1925 531 
+L 3022 4666 
+L 3675 4666 
+L 2309 0 
+L 1544 0 
+L 178 4666 
+L 831 4666 
+L 1925 531 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-26" d="M 3353 166 
+Q 3113 38 2859 -26 
+Q 2606 -91 2322 -91 
+Q 1425 -91 929 543 
+Q 434 1178 434 2328 
+Q 434 3472 932 4111 
+Q 1431 4750 2322 4750 
+Q 2606 4750 2859 4686 
+Q 3113 4622 3353 4494 
+L 3353 3847 
+Q 3122 4038 2856 4138 
+Q 2591 4238 2322 4238 
+Q 1706 4238 1400 3763 
+Q 1094 3288 1094 2328 
+Q 1094 1372 1400 897 
+Q 1706 422 2322 422 
+Q 2597 422 2861 522 
+Q 3125 622 3353 813 
+L 3353 166 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-32"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-39" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(1083.65625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(1143.859375 0)"/>
+    </g>
+   </g>
+   <g id="patch_7">
+    <path d="M 18.14875 174.18452 
+L 18.14875 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 18.14875 174.18452 
+L 252.535145 174.18452 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_9">
+    <path d="M 270.813125 174.18452 
+L 505.19952 174.18452 
+L 505.19952 20.037891 
+L 270.813125 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_5">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="270.813125" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 0 -->
+      <g transform="translate(268.58875 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="308.017315" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1 -->
+      <g transform="translate(305.79294 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="345.221504" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(342.997129 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="382.425694" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 3 -->
+      <g transform="translate(380.201319 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="419.629884" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 4 -->
+      <g transform="translate(417.405509 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_10">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="456.834073" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 5 -->
+      <g transform="translate(454.609698 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m46d911fdbc" x="494.038263" y="174.18452" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 6 -->
+      <g transform="translate(491.813888 186.68452) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_8">
+     <g id="line2d_26">
+      <path d="M 270.813125 152.426981 
+L 505.19952 152.426981 
+" clip-path="url(#p2bf8e0c2b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="270.813125" y="152.426981" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_20">
+      <!-- w -->
+      <g transform="translate(258.535625 155.426981) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5a"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_28">
+      <path d="M 270.813125 115.549797 
+L 505.19952 115.549797 
+" clip-path="url(#p2bf8e0c2b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="270.813125" y="115.549797" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- x -->
+      <g transform="translate(260.313125 118.549797) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5b"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_30">
+      <path d="M 270.813125 78.672613 
+L 505.19952 78.672613 
+" clip-path="url(#p2bf8e0c2b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="270.813125" y="78.672613" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- y -->
+      <g transform="translate(260.313125 81.672613) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5c"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_32">
+      <path d="M 270.813125 41.795429 
+L 505.19952 41.795429 
+" clip-path="url(#p2bf8e0c2b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m8f77a8a4f2" x="270.813125" y="41.795429" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- z -->
+      <g transform="translate(260.313125 44.795429) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-5d"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_10">
+    <path d="M 270.813125 167.177855 
+L 419.629884 167.177855 
+L 419.629884 137.676108 
+L 270.813125 137.676108 
+z
+" clip-path="url(#p2bf8e0c2b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 270.813125 130.300671 
+L 494.038263 130.300671 
+L 494.038263 100.798924 
+L 270.813125 100.798924 
+z
+" clip-path="url(#p2bf8e0c2b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 270.813125 93.423487 
+L 382.425694 93.423487 
+L 382.425694 63.92174 
+L 270.813125 63.92174 
+z
+" clip-path="url(#p2bf8e0c2b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 270.813125 56.546303 
+L 456.834073 56.546303 
+L 456.834073 27.044556 
+L 270.813125 27.044556 
+z
+" clip-path="url(#p2bf8e0c2b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.6; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_24">
+    <!-- ORIENTATION.HORIZONTAL -->
+    <g transform="translate(328.405229 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-2b" d="M 428 4666 
+L 1063 4666 
+L 1063 2753 
+L 2791 2753 
+L 2791 4666 
+L 3425 4666 
+L 3425 0 
+L 2791 0 
+L 2791 2222 
+L 1063 2222 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-3d" d="M 556 4666 
+L 3584 4666 
+L 3584 4184 
+L 1147 531 
+L 3653 531 
+L 3653 0 
+L 488 0 
+L 488 481 
+L 2859 4134 
+L 556 4134 
+L 556 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-32"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3d" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(1083.65625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(1143.859375 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(1204.0625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(1264.265625 0)"/>
+    </g>
+   </g>
+   <g id="patch_14">
+    <path d="M 270.813125 174.18452 
+L 270.813125 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 270.813125 174.18452 
+L 505.19952 174.18452 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p9305292673">
+   <rect x="18.14875" y="20.037891" width="234.386395" height="154.146629"/>
+  </clipPath>
+  <clipPath id="p2bf8e0c2b7">
+   <rect x="270.813125" y="20.037891" width="234.386395" height="154.146629"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-scale.svg
+++ b/docs/assets/imgs/const-scale.svg
@@ -1,0 +1,2533 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="154.345752pt" viewBox="0 0 515.39976 154.345752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:25.890276</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 154.345752 
+L 515.39976 154.345752 
+L 515.39976 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 43.39274 124.140145 
+L 140.979135 124.140145 
+L 140.979135 20.037891 
+L 43.39274 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m50cab8319e" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m50cab8319e" x="43.39274" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(41.168365 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m50cab8319e" x="82.427298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(80.202923 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m50cab8319e" x="121.461856" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(119.237481 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <path d="M 43.39274 119.409171 
+L 140.979135 119.409171 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_5">
+      <defs>
+       <path id="mc85c8f87f9" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="43.39274" y="119.409171" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 0 -->
+      <g transform="translate(32.44399 122.409171) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_6">
+      <path d="M 43.39274 100.481299 
+L 140.979135 100.481299 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="43.39274" y="100.481299" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 20000 -->
+      <g transform="translate(14.64899 103.481299) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(222.4375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_8">
+      <path d="M 43.39274 81.553427 
+L 140.979135 81.553427 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="43.39274" y="81.553427" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 40000 -->
+      <g transform="translate(14.64899 84.553427) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(222.4375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_10">
+      <path d="M 43.39274 62.625555 
+L 140.979135 62.625555 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="43.39274" y="62.625555" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 60000 -->
+      <g transform="translate(14.64899 65.625555) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(222.4375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_12">
+      <path d="M 43.39274 43.697683 
+L 140.979135 43.697683 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="43.39274" y="43.697683" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 80000 -->
+      <g transform="translate(14.64899 46.697683) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-1b" d="M 1741 2600 
+Q 2113 2600 2322 2808 
+Q 2531 3016 2531 3303 
+Q 2531 3553 2331 3762 
+Q 2131 3972 1722 3972 
+Q 1316 3972 1134 3762 
+Q 953 3553 953 3272 
+Q 953 2956 1187 2778 
+Q 1422 2600 1741 2600 
+z
+M 1775 384 
+Q 2166 384 2423 595 
+Q 2681 806 2681 1225 
+Q 2681 1659 2415 1884 
+Q 2150 2109 1734 2109 
+Q 1331 2109 1076 1879 
+Q 822 1650 822 1244 
+Q 822 894 1055 639 
+Q 1288 384 1775 384 
+z
+M 975 2384 
+Q 741 2484 609 2619 
+Q 363 2869 363 3269 
+Q 363 3769 725 4128 
+Q 1088 4488 1753 4488 
+Q 2397 4488 2762 4148 
+Q 3128 3809 3128 3356 
+Q 3128 2938 2916 2678 
+Q 2797 2531 2547 2391 
+Q 2825 2263 2984 2097 
+Q 3281 1784 3281 1284 
+Q 3281 694 2884 283 
+Q 2488 -128 1763 -128 
+Q 1109 -128 657 226 
+Q 206 581 206 1256 
+Q 206 1653 400 1942 
+Q 594 2231 975 2384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-1b"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(222.4375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_14">
+      <path d="M 43.39274 24.769811 
+L 140.979135 24.769811 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="43.39274" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 100000 -->
+      <g transform="translate(10.20024 27.769811) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(166.828125 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(222.4375 0)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(278.046875 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_16">
+    <path d="M 43.39274 119.408224 
+L 62.910019 119.399707 
+L 82.427298 119.314531 
+L 101.944577 118.462777 
+L 121.461856 109.945235 
+L 140.979135 24.769811 
+" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <!-- SCALE.LINEAR -->
+    <g transform="translate(59.67625 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-26" d="M 3353 166 
+Q 3113 38 2859 -26 
+Q 2606 -91 2322 -91 
+Q 1425 -91 929 543 
+Q 434 1178 434 2328 
+Q 434 3472 932 4111 
+Q 1431 4750 2322 4750 
+Q 2606 4750 2859 4686 
+Q 3113 4622 3353 4494 
+L 3353 3847 
+Q 3122 4038 2856 4138 
+Q 2591 4238 2322 4238 
+Q 1706 4238 1400 3763 
+Q 1094 3288 1094 2328 
+Q 1094 1372 1400 897 
+Q 1706 422 2322 422 
+Q 2597 422 2861 522 
+Q 3125 622 3353 813 
+L 3353 166 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-24" d="M 1925 4109 
+L 1259 1722 
+L 2591 1722 
+L 1925 4109 
+z
+M 1544 4666 
+L 2309 4666 
+L 3738 0 
+L 3084 0 
+L 2741 1216 
+L 1106 1216 
+L 769 0 
+L 116 0 
+L 1544 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-31" d="M 434 4666 
+L 1234 4666 
+L 2809 825 
+L 2809 4666 
+L 3419 4666 
+L 3419 0 
+L 2619 0 
+L 1044 3841 
+L 1044 0 
+L 434 0 
+L 434 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(662.234375 0)"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 43.39274 124.140145 
+L 43.39274 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 43.39274 124.140145 
+L 140.979135 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 165.799615 124.140145 
+L 263.38601 124.140145 
+L 263.38601 20.037891 
+L 165.799615 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_4">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m50cab8319e" x="165.799615" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0 -->
+      <g transform="translate(163.57524 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m50cab8319e" x="204.834173" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 2 -->
+      <g transform="translate(202.609798 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m50cab8319e" x="243.868731" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 4 -->
+      <g transform="translate(241.644356 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_20">
+      <path d="M 165.799615 119.408224 
+L 263.38601 119.408224 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="165.799615" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(146.979615 123.048224) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.754688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.754688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(112.1875 42.054688) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_22">
+      <path d="M 165.799615 100.480542 
+L 263.38601 100.480542 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="165.799615" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(146.979615 104.120542) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.9625)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.9625)"/>
+       <use xlink:href="#Helvetica-14" transform="translate(112.1875 42.2625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_24">
+      <path d="M 165.799615 81.552859 
+L 263.38601 81.552859 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="165.799615" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(146.979615 85.192859) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.579688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.579688)"/>
+       <use xlink:href="#Helvetica-15" transform="translate(112.1875 41.879688) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_26">
+      <path d="M 165.799615 62.625177 
+L 263.38601 62.625177 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_27">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="165.799615" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(146.979615 66.265177) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.689063)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.689063)"/>
+       <use xlink:href="#Helvetica-16" transform="translate(112.1875 41.989063) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_28">
+      <path d="M 165.799615 43.697494 
+L 263.38601 43.697494 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_29">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="165.799615" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(146.979615 47.337494) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.6125)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.6125)"/>
+       <use xlink:href="#Helvetica-17" transform="translate(112.1875 41.9125) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_30">
+      <path d="M 165.799615 24.769811 
+L 263.38601 24.769811 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_31">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="165.799615" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(146.979615 28.369811) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.575)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.575)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(112.1875 41.875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_13">
+     <g id="line2d_32">
+      <defs>
+       <path id="m0336e7fa9f" d="M 0 0 
+L -2 0 
+" style="stroke: #000000; stroke-width: 0.6"/>
+      </defs>
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="123.607307" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_33">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="122.340159" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="121.242506" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_35">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="120.274308" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="113.710424" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="110.377425" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_19">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="108.012624" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="106.178342" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="104.679624" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="103.412477" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="102.314824" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="101.346625" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_25">
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="94.782742" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_26">
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="91.449742" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_27">
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="89.084941" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_28">
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="87.250659" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_29">
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="85.751942" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_30">
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="84.484794" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_31">
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="83.387141" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_32">
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="82.418942" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_33">
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="75.855059" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_34">
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="72.522059" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_35">
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="70.157259" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_36">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="68.322977" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_37">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="66.824259" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_38">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="65.557112" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_39">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="64.459458" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_40">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="63.49126" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_41">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="56.927376" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_42">
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="53.594377" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_43">
+     <g id="line2d_62">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="51.229576" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_44">
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="49.395294" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_45">
+     <g id="line2d_64">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="47.896577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_46">
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="46.629429" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_47">
+     <g id="line2d_66">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="45.531776" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_48">
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="44.563577" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_49">
+     <g id="line2d_68">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="37.999694" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_50">
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="34.666694" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_51">
+     <g id="line2d_70">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="32.301893" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_52">
+     <g id="line2d_71">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="30.467611" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_53">
+     <g id="line2d_72">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="28.968894" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_54">
+     <g id="line2d_73">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="27.701746" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_55">
+     <g id="line2d_74">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="26.604093" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_56">
+     <g id="line2d_75">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="165.799615" y="25.635895" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_76">
+    <path d="M 165.799615 119.408224 
+L 185.316894 100.480542 
+L 204.834173 81.552859 
+L 224.351452 62.625177 
+L 243.868731 43.697494 
+L 263.38601 24.769811 
+" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_20">
+    <!-- SCALE.LOG -->
+    <g transform="translate(190.210547 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2a" d="M 3450 384 
+Q 3197 150 2880 29 
+Q 2563 -91 2194 -91 
+Q 1306 -91 812 545 
+Q 319 1181 319 2328 
+Q 319 3472 819 4111 
+Q 1319 4750 2209 4750 
+Q 2503 4750 2772 4667 
+Q 3041 4584 3291 4416 
+L 3291 3769 
+Q 3038 4009 2772 4123 
+Q 2506 4238 2209 4238 
+Q 1594 4238 1286 3761 
+Q 978 3284 978 2328 
+Q 978 1356 1276 889 
+Q 1575 422 2194 422 
+Q 2403 422 2561 470 
+Q 2719 519 2847 622 
+L 2847 1875 
+L 2169 1875 
+L 2169 2394 
+L 3450 2394 
+L 3450 384 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(481.625 0)"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 165.799615 124.140145 
+L 165.799615 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 165.799615 124.140145 
+L 263.38601 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_8">
+    <path d="M 288.20649 124.140145 
+L 385.792885 124.140145 
+L 385.792885 20.037891 
+L 288.20649 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_7">
+     <g id="line2d_77">
+      <g>
+       <use xlink:href="#m50cab8319e" x="288.20649" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 0 -->
+      <g transform="translate(285.982115 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_78">
+      <g>
+       <use xlink:href="#m50cab8319e" x="327.241048" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 2 -->
+      <g transform="translate(325.016673 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_79">
+      <g>
+       <use xlink:href="#m50cab8319e" x="366.275606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 4 -->
+      <g transform="translate(364.051231 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_57">
+     <g id="line2d_80">
+      <path d="M 288.20649 119.408224 
+L 385.792885 119.408224 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_81">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="288.20649" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(269.38649 123.048224) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.754688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.754688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(112.1875 42.054688) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_58">
+     <g id="line2d_82">
+      <path d="M 288.20649 96.813167 
+L 385.792885 96.813167 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_83">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="288.20649" y="96.813167" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(269.38649 100.453167) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.9625)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.9625)"/>
+       <use xlink:href="#Helvetica-14" transform="translate(112.1875 42.2625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_59">
+     <g id="line2d_84">
+      <path d="M 288.20649 78.802328 
+L 385.792885 78.802328 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_85">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="288.20649" y="78.802328" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(269.38649 82.442328) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.579688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.579688)"/>
+       <use xlink:href="#Helvetica-15" transform="translate(112.1875 41.879688) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_60">
+     <g id="line2d_86">
+      <path d="M 288.20649 60.791489 
+L 385.792885 60.791489 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_87">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="288.20649" y="60.791489" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(269.38649 64.431489) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.689063)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.689063)"/>
+       <use xlink:href="#Helvetica-16" transform="translate(112.1875 41.989063) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_61">
+     <g id="line2d_88">
+      <path d="M 288.20649 42.78065 
+L 385.792885 42.78065 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_89">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="288.20649" y="42.78065" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(269.38649 46.42065) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.6125)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.6125)"/>
+       <use xlink:href="#Helvetica-17" transform="translate(112.1875 41.9125) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_62">
+     <g id="line2d_90">
+      <path d="M 288.20649 24.769811 
+L 385.792885 24.769811 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_91">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="288.20649" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(269.38649 28.369811) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.575)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.575)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(112.1875 41.875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_92">
+    <path d="M 288.20649 119.408224 
+L 307.723769 96.813167 
+L 327.241048 78.802328 
+L 346.758327 60.791489 
+L 366.275606 42.78065 
+L 385.792885 24.769811 
+" clip-path="url(#p4324388e45)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_30">
+    <!-- SCALE.SYMLOG -->
+    <g transform="translate(304.49 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-3c" d="M 116 4666 
+L 788 4666 
+L 1925 2606 
+L 3059 4666 
+L 3738 4666 
+L 2241 2094 
+L 2241 0 
+L 1606 0 
+L 1606 2094 
+L 116 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-30" d="M 269 4666 
+L 1113 4666 
+L 1919 2291 
+L 2731 4666 
+L 3578 4666 
+L 3578 0 
+L 2994 0 
+L 2994 4122 
+L 2163 1663 
+L 1684 1663 
+L 850 4122 
+L 850 0 
+L 269 0 
+L 269 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(662.234375 0)"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 288.20649 124.140145 
+L 288.20649 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 288.20649 124.140145 
+L 385.792885 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_11">
+    <path d="M 410.613365 124.140145 
+L 508.19976 124.140145 
+L 508.19976 20.037891 
+L 410.613365 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_10">
+     <g id="line2d_93">
+      <g>
+       <use xlink:href="#m50cab8319e" x="410.613365" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 0 -->
+      <g transform="translate(408.38899 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_94">
+      <g>
+       <use xlink:href="#m50cab8319e" x="449.647923" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 2 -->
+      <g transform="translate(447.423548 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_95">
+      <g>
+       <use xlink:href="#m50cab8319e" x="488.682481" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 4 -->
+      <g transform="translate(486.458106 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_63">
+     <g id="line2d_96">
+      <path d="M 410.613365 119.408224 
+L 508.19976 119.408224 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_97">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="410.613365" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- $\mathdefault{10^{0}}$ -->
+      <g transform="translate(391.793365 123.048224) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.754688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.754688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(112.1875 42.054688) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_64">
+     <g id="line2d_98">
+      <path d="M 410.613365 101.718106 
+L 508.19976 101.718106 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_99">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="410.613365" y="101.718106" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- $\mathdefault{10^{1}}$ -->
+      <g transform="translate(391.793365 105.358106) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.9625)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.9625)"/>
+       <use xlink:href="#Helvetica-14" transform="translate(112.1875 42.2625) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_65">
+     <g id="line2d_100">
+      <path d="M 410.613365 82.496434 
+L 508.19976 82.496434 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_101">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="410.613365" y="82.496434" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- $\mathdefault{10^{2}}$ -->
+      <g transform="translate(391.793365 86.136434) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.579688)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.579688)"/>
+       <use xlink:href="#Helvetica-15" transform="translate(112.1875 41.879688) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_66">
+     <g id="line2d_102">
+      <path d="M 410.613365 63.254364 
+L 508.19976 63.254364 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_103">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="410.613365" y="63.254364" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- $\mathdefault{10^{3}}$ -->
+      <g transform="translate(391.793365 66.894364) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.689063)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.689063)"/>
+       <use xlink:href="#Helvetica-16" transform="translate(112.1875 41.989063) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_67">
+     <g id="line2d_104">
+      <path d="M 410.613365 44.012089 
+L 508.19976 44.012089 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_105">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="410.613365" y="44.012089" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- $\mathdefault{10^{4}}$ -->
+      <g transform="translate(391.793365 47.652089) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.6125)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.6125)"/>
+       <use xlink:href="#Helvetica-17" transform="translate(112.1875 41.9125) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_68">
+     <g id="line2d_106">
+      <path d="M 410.613365 24.769811 
+L 508.19976 24.769811 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_107">
+      <g>
+       <use xlink:href="#mc85c8f87f9" x="410.613365" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_39">
+      <!-- $\mathdefault{10^{5}}$ -->
+      <g transform="translate(391.793365 28.369811) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14" transform="translate(0 0.575)"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.575)"/>
+       <use xlink:href="#Helvetica-18" transform="translate(112.1875 41.875) scale(0.7)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_69">
+     <g id="line2d_108">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="122.752302" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_70">
+     <g id="line2d_109">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="114.709506" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_71">
+     <g id="line2d_110">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="107.449081" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_72">
+     <g id="line2d_111">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="95.9412" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_73">
+     <g id="line2d_112">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="88.28831" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_74">
+     <g id="line2d_113">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="76.704088" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_75">
+     <g id="line2d_114">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="69.04686" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_76">
+     <g id="line2d_115">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="57.461863" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_77">
+     <g id="line2d_116">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="49.804591" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_78">
+     <g id="line2d_117">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="38.219586" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_79">
+     <g id="line2d_118">
+      <g>
+       <use xlink:href="#m0336e7fa9f" x="410.613365" y="30.562314" style="stroke: #000000; stroke-width: 0.6"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_119">
+    <path d="M 410.613365 119.408224 
+L 430.130644 101.718106 
+L 449.647923 82.496434 
+L 469.165202 63.254364 
+L 488.682481 44.012089 
+L 508.19976 24.769811 
+" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_40">
+    <!-- SCALE.ASINH -->
+    <g transform="translate(429.606016 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-2b" d="M 428 4666 
+L 1063 4666 
+L 1063 2753 
+L 2791 2753 
+L 2791 4666 
+L 3425 4666 
+L 3425 0 
+L 2791 0 
+L 2791 2222 
+L 1063 2222 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-26" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-2f" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(602.03125 0)"/>
+    </g>
+   </g>
+   <g id="patch_12">
+    <path d="M 410.613365 124.140145 
+L 410.613365 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 410.613365 124.140145 
+L 508.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_41">
+   <!-- Same growth data on each value axis; SYMLOG and ASINH also accept zero and negative values. -->
+   <g transform="translate(7.2 145.10376) scale(0.085 -0.085)">
+    <defs>
+     <path id="DejaVuSans-Oblique-36" d="M 3859 4513 
+L 3738 3897 
+Q 3422 4066 3111 4152 
+Q 2800 4238 2509 4238 
+Q 1944 4238 1609 3991 
+Q 1275 3744 1275 3334 
+Q 1275 3109 1398 2989 
+Q 1522 2869 2034 2731 
+L 2413 2638 
+Q 3053 2472 3303 2217 
+Q 3553 1963 3553 1503 
+Q 3553 797 2998 353 
+Q 2444 -91 1538 -91 
+Q 1166 -91 791 -17 
+Q 416 56 38 206 
+L 166 856 
+Q 513 641 861 531 
+Q 1209 422 1556 422 
+Q 2147 422 2503 684 
+Q 2859 947 2859 1369 
+Q 2859 1650 2717 1795 
+Q 2575 1941 2106 2059 
+L 1728 2156 
+Q 1081 2325 845 2545 
+Q 609 2766 609 3163 
+Q 609 3859 1145 4304 
+Q 1681 4750 2541 4750 
+Q 2875 4750 3203 4690 
+Q 3531 4631 3859 4513 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5a" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-59" d="M 459 3500 
+L 1069 3500 
+L 1581 525 
+L 3256 3500 
+L 3866 3500 
+L 1875 0 
+L 1100 0 
+L 459 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-58" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5b" d="M 3841 3500 
+L 2234 1784 
+L 3219 0 
+L 2559 0 
+L 1819 1388 
+L 531 0 
+L -166 0 
+L 1556 1844 
+L 641 3500 
+L 1300 3500 
+L 1972 2234 
+L 3144 3500 
+L 3841 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3c" d="M 403 4666 
+L 1081 4666 
+L 1953 2747 
+L 3616 4666 
+L 4325 4666 
+L 2209 2222 
+L 1778 0 
+L 1147 0 
+L 1575 2222 
+L 403 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-30" d="M 1081 4666 
+L 2028 4666 
+L 2572 1522 
+L 4378 4666 
+L 5350 4666 
+L 4441 0 
+L 3828 0 
+L 4622 4091 
+L 2791 897 
+L 2175 897 
+L 1581 4103 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2f" d="M 1075 4666 
+L 1709 4666 
+L 909 525 
+L 3181 525 
+L 3078 0 
+L 172 0 
+L 1075 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-32" d="M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+M 2100 -91 
+Q 1241 -91 748 418 
+Q 256 928 256 1813 
+Q 256 2319 448 2847 
+Q 641 3375 978 3788 
+Q 1375 4272 1862 4511 
+Q 2350 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 2331 4593 1812 
+Q 4406 1294 4056 872 
+Q 3656 384 3173 146 
+Q 2691 -91 2100 -91 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2a" d="M 3494 697 
+L 3738 1919 
+L 2700 1919 
+L 2797 2438 
+L 4453 2438 
+L 4050 384 
+Q 3634 156 3143 32 
+Q 2653 -91 2156 -91 
+Q 1278 -91 783 396 
+Q 288 884 288 1753 
+Q 288 2475 589 3126 
+Q 891 3778 1422 4213 
+Q 1756 4484 2153 4617 
+Q 2550 4750 3034 4750 
+Q 3472 4750 3873 4639 
+Q 4275 4528 4641 4306 
+L 4513 3634 
+Q 4231 3928 3853 4083 
+Q 3475 4238 3047 4238 
+Q 2550 4238 2172 4048 
+Q 1794 3859 1497 3463 
+Q 1244 3125 1098 2667 
+Q 953 2209 953 1734 
+Q 953 1081 1287 751 
+Q 1622 422 2284 422 
+Q 2616 422 2925 492 
+Q 3234 563 3494 697 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-24" d="M 2356 4666 
+L 3072 4666 
+L 3938 0 
+L 3278 0 
+L 3084 1197 
+L 984 1197 
+L 325 0 
+L -341 0 
+L 2356 4666 
+z
+M 2584 4044 
+L 1275 1722 
+L 2988 1722 
+L 2584 4044 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2c" d="M 1081 4666 
+L 1716 4666 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-31" d="M 1081 4666 
+L 1931 4666 
+L 3219 666 
+L 4000 4666 
+L 4616 4666 
+L 3706 0 
+L 2853 0 
+L 1569 4025 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-2b" d="M 1081 4666 
+L 1716 4666 
+L 1344 2753 
+L 3634 2753 
+L 4006 4666 
+L 4641 4666 
+L 3731 0 
+L 3097 0 
+L 3531 2222 
+L 1241 2222 
+L 806 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5d" d="M 744 3500 
+L 3475 3500 
+L 3372 2975 
+L 738 459 
+L 2913 459 
+L 2822 0 
+L -19 0 
+L 84 525 
+L 2719 3041 
+L 653 3041 
+L 744 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-11" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-36"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(63.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(124.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(222.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(283.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(315.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(378.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(420.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(481.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(563.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(602.25 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(665.625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(697.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(760.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(822.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(861.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(922.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(954.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(1015.625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1079 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1110.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1172.3125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(1233.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1288.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1351.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(1383.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1442.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(1504.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(1531.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1595.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1656.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1688.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5b" transform="translate(1749.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1809.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1836.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(1889.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1922.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(1954.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3c" transform="translate(2017.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-30" transform="translate(2079.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2f" transform="translate(2165.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-32" transform="translate(2217.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2a" transform="translate(2296.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2374.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2405.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(2467.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(2530.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2594.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(2625.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(2694.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2c" transform="translate(2757.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(2787.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-2b" transform="translate(2862.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2937.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2969.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(3030.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3058.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3110.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3171.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(3203.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(3264.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(3319.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3374.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(3435.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3499.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3538.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5d" transform="translate(3570.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3622.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(3684.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3725.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3786.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(3818.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(3879.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(3943.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4006.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(4038.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4101.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(4163.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(4226.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(4288.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(4327.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(4355.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4414.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4475.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(4507.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(4566.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4628.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(4655.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4719.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(4780.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(4832.859375 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p5d6a8f26ac">
+   <rect x="43.39274" y="20.037891" width="97.586395" height="104.102254"/>
+  </clipPath>
+  <clipPath id="p3a99cd5ba9">
+   <rect x="165.799615" y="20.037891" width="97.586395" height="104.102254"/>
+  </clipPath>
+  <clipPath id="p4324388e45">
+   <rect x="288.20649" y="20.037891" width="97.586395" height="104.102254"/>
+  </clipPath>
+  <clipPath id="pad4050efa4">
+   <rect x="410.613365" y="20.037891" width="97.586395" height="104.102254"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-scale.svg
+++ b/docs/assets/imgs/const-scale.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="154.345752pt" viewBox="0 0 515.39976 154.345752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="166.081752pt" viewBox="0 0 512.39952 166.081752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:34:25.890276</dc:date>
+    <dc:date>2026-08-23T23:46:43.614702</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,19 +21,19 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 154.345752 
-L 515.39976 154.345752 
-L 515.39976 0 
+   <path d="M 0 166.081752 
+L 512.39952 166.081752 
+L 512.39952 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 43.39274 124.140145 
-L 140.979135 124.140145 
-L 140.979135 20.037891 
-L 43.39274 20.037891 
+    <path d="M 40.3925 124.140145 
+L 137.978895 124.140145 
+L 137.978895 20.037891 
+L 40.3925 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,17 +41,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m50cab8319e" d="M 0 0 
+       <path id="mc655f1a076" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m50cab8319e" x="43.39274" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="40.3925" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0 -->
-      <g transform="translate(41.168365 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(38.168125 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -82,12 +82,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m50cab8319e" x="82.427298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="79.427058" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 2 -->
-      <g transform="translate(80.202923 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(77.202683 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-15" d="M 200 0 
 Q 231 578 439 1006 
@@ -122,12 +122,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m50cab8319e" x="121.461856" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="118.461616" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 4 -->
-      <g transform="translate(119.237481 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(116.237241 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -157,41 +157,41 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_4">
-      <path d="M 43.39274 119.409171 
-L 140.979135 119.409171 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 40.3925 119.409171 
+L 137.978895 119.409171 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_5">
       <defs>
-       <path id="mc85c8f87f9" d="M 0 0 
+       <path id="me217b0e9ea" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#mc85c8f87f9" x="43.39274" y="119.409171" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="40.3925" y="119.409171" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 0 -->
-      <g transform="translate(32.44399 122.409171) scale(0.08 -0.08)">
+      <g transform="translate(29.44375 122.409171) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_6">
-      <path d="M 43.39274 100.481299 
-L 140.979135 100.481299 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 40.3925 100.481299 
+L 137.978895 100.481299 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_7">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="43.39274" y="100.481299" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="40.3925" y="100.481299" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 20000 -->
-      <g transform="translate(14.64899 103.481299) scale(0.08 -0.08)">
+      <g transform="translate(11.64875 103.481299) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
@@ -202,18 +202,18 @@ L 140.979135 100.481299
     </g>
     <g id="ytick_3">
      <g id="line2d_8">
-      <path d="M 43.39274 81.553427 
-L 140.979135 81.553427 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 40.3925 81.553427 
+L 137.978895 81.553427 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_9">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="43.39274" y="81.553427" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="40.3925" y="81.553427" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 40000 -->
-      <g transform="translate(14.64899 84.553427) scale(0.08 -0.08)">
+      <g transform="translate(11.64875 84.553427) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
        <use xlink:href="#Helvetica-13" transform="translate(111.21875 0)"/>
@@ -224,18 +224,18 @@ L 140.979135 81.553427
     </g>
     <g id="ytick_4">
      <g id="line2d_10">
-      <path d="M 43.39274 62.625555 
-L 140.979135 62.625555 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 40.3925 62.625555 
+L 137.978895 62.625555 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_11">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="43.39274" y="62.625555" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="40.3925" y="62.625555" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 60000 -->
-      <g transform="translate(14.64899 65.625555) scale(0.08 -0.08)">
+      <g transform="translate(11.64875 65.625555) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-19" d="M 1872 4494 
 Q 2622 4494 2917 4105 
@@ -278,18 +278,18 @@ z
     </g>
     <g id="ytick_5">
      <g id="line2d_12">
-      <path d="M 43.39274 43.697683 
-L 140.979135 43.697683 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 40.3925 43.697683 
+L 137.978895 43.697683 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_13">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="43.39274" y="43.697683" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="40.3925" y="43.697683" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 80000 -->
-      <g transform="translate(14.64899 46.697683) scale(0.08 -0.08)">
+      <g transform="translate(11.64875 46.697683) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-1b" d="M 1741 2600 
 Q 2113 2600 2322 2808 
@@ -341,18 +341,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_14">
-      <path d="M 43.39274 24.769811 
-L 140.979135 24.769811 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 40.3925 24.769811 
+L 137.978895 24.769811 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_15">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="43.39274" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="40.3925" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 100000 -->
-      <g transform="translate(10.20024 27.769811) scale(0.08 -0.08)">
+      <g transform="translate(7.2 27.769811) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -377,17 +377,17 @@ z
     </g>
    </g>
    <g id="line2d_16">
-    <path d="M 43.39274 119.408224 
-L 62.910019 119.399707 
-L 82.427298 119.314531 
-L 101.944577 118.462777 
-L 121.461856 109.945235 
-L 140.979135 24.769811 
-" clip-path="url(#p5d6a8f26ac)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 40.3925 119.408224 
+L 59.909779 119.399707 
+L 79.427058 119.314531 
+L 98.944337 118.462777 
+L 118.461616 109.945235 
+L 137.978895 24.769811 
+" clip-path="url(#pb74072fc43)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_10">
     <!-- SCALE.LINEAR -->
-    <g transform="translate(59.67625 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(56.67601 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-36" d="M 3163 4506 
 L 3163 3866 
@@ -560,22 +560,22 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 43.39274 124.140145 
-L 43.39274 20.037891 
+    <path d="M 40.3925 124.140145 
+L 40.3925 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 43.39274 124.140145 
-L 140.979135 124.140145 
+    <path d="M 40.3925 124.140145 
+L 137.978895 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_5">
-    <path d="M 165.799615 124.140145 
-L 263.38601 124.140145 
-L 263.38601 20.037891 
-L 165.799615 20.037891 
+    <path d="M 162.799375 124.140145 
+L 260.38577 124.140145 
+L 260.38577 20.037891 
+L 162.799375 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -583,12 +583,12 @@ z
     <g id="xtick_4">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m50cab8319e" x="165.799615" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="162.799375" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0 -->
-      <g transform="translate(163.57524 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(160.575 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -596,12 +596,12 @@ z
     <g id="xtick_5">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m50cab8319e" x="204.834173" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="201.833933" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 2 -->
-      <g transform="translate(202.609798 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(199.609558 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -609,12 +609,12 @@ z
     <g id="xtick_6">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m50cab8319e" x="243.868731" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="240.868491" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 4 -->
-      <g transform="translate(241.644356 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(238.644116 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -623,18 +623,18 @@ z
    <g id="matplotlib.axis_4">
     <g id="ytick_7">
      <g id="line2d_20">
-      <path d="M 165.799615 119.408224 
-L 263.38601 119.408224 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 162.799375 119.408224 
+L 260.38577 119.408224 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_21">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="165.799615" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="162.799375" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(146.979615 123.048224) scale(0.08 -0.08)">
+      <g transform="translate(143.979375 123.048224) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.754688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.754688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(112.1875 42.054688) scale(0.7)"/>
@@ -643,18 +643,18 @@ L 263.38601 119.408224
     </g>
     <g id="ytick_8">
      <g id="line2d_22">
-      <path d="M 165.799615 100.480542 
-L 263.38601 100.480542 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 162.799375 100.480542 
+L 260.38577 100.480542 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_23">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="165.799615" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="162.799375" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(146.979615 104.120542) scale(0.08 -0.08)">
+      <g transform="translate(143.979375 104.120542) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.9625)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.9625)"/>
        <use xlink:href="#Helvetica-14" transform="translate(112.1875 42.2625) scale(0.7)"/>
@@ -663,18 +663,18 @@ L 263.38601 100.480542
     </g>
     <g id="ytick_9">
      <g id="line2d_24">
-      <path d="M 165.799615 81.552859 
-L 263.38601 81.552859 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 162.799375 81.552859 
+L 260.38577 81.552859 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_25">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="165.799615" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="162.799375" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(146.979615 85.192859) scale(0.08 -0.08)">
+      <g transform="translate(143.979375 85.192859) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.579688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.579688)"/>
        <use xlink:href="#Helvetica-15" transform="translate(112.1875 41.879688) scale(0.7)"/>
@@ -683,18 +683,18 @@ L 263.38601 81.552859
     </g>
     <g id="ytick_10">
      <g id="line2d_26">
-      <path d="M 165.799615 62.625177 
-L 263.38601 62.625177 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 162.799375 62.625177 
+L 260.38577 62.625177 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_27">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="165.799615" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="162.799375" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(146.979615 66.265177) scale(0.08 -0.08)">
+      <g transform="translate(143.979375 66.265177) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -739,18 +739,18 @@ z
     </g>
     <g id="ytick_11">
      <g id="line2d_28">
-      <path d="M 165.799615 43.697494 
-L 263.38601 43.697494 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 162.799375 43.697494 
+L 260.38577 43.697494 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_29">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="165.799615" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="162.799375" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(146.979615 47.337494) scale(0.08 -0.08)">
+      <g transform="translate(143.979375 47.337494) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.6125)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.6125)"/>
        <use xlink:href="#Helvetica-17" transform="translate(112.1875 41.9125) scale(0.7)"/>
@@ -759,18 +759,18 @@ L 263.38601 43.697494
     </g>
     <g id="ytick_12">
      <g id="line2d_30">
-      <path d="M 165.799615 24.769811 
-L 263.38601 24.769811 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 162.799375 24.769811 
+L 260.38577 24.769811 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_31">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="165.799615" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="162.799375" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g transform="translate(146.979615 28.369811) scale(0.08 -0.08)">
+      <g transform="translate(143.979375 28.369811) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-18" d="M 791 1141 
 Q 847 659 1238 475 
@@ -808,329 +808,329 @@ z
     <g id="ytick_13">
      <g id="line2d_32">
       <defs>
-       <path id="m0336e7fa9f" d="M 0 0 
+       <path id="mfd956b8d52" d="M 0 0 
 L -2 0 
 " style="stroke: #000000; stroke-width: 0.6"/>
       </defs>
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="123.607307" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="123.607307" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_33">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="122.340159" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="122.340159" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="121.242506" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="121.242506" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_35">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="120.274308" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="120.274308" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="113.710424" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="113.710424" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_37">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="110.377425" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="110.377425" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="108.012624" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="108.012624" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_39">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="106.178342" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="106.178342" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_40">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="104.679624" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="104.679624" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="103.412477" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="103.412477" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_42">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="102.314824" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="102.314824" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="101.346625" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="101.346625" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_25">
      <g id="line2d_44">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="94.782742" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="94.782742" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="91.449742" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="91.449742" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_46">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="89.084941" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="89.084941" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="87.250659" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="87.250659" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_48">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="85.751942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="85.751942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="84.484794" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="84.484794" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_50">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="83.387141" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="83.387141" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="82.418942" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="82.418942" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_52">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="75.855059" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="75.855059" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="72.522059" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="72.522059" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_54">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="70.157259" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="70.157259" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="68.322977" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="68.322977" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_37">
      <g id="line2d_56">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="66.824259" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="66.824259" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_38">
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="65.557112" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="65.557112" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_39">
      <g id="line2d_58">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="64.459458" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="64.459458" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_40">
      <g id="line2d_59">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="63.49126" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="63.49126" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_41">
      <g id="line2d_60">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="56.927376" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="56.927376" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_42">
      <g id="line2d_61">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="53.594377" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="53.594377" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_43">
      <g id="line2d_62">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="51.229576" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="51.229576" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_44">
      <g id="line2d_63">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="49.395294" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="49.395294" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_45">
      <g id="line2d_64">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="47.896577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="47.896577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_46">
      <g id="line2d_65">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="46.629429" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="46.629429" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_47">
      <g id="line2d_66">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="45.531776" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="45.531776" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_48">
      <g id="line2d_67">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="44.563577" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="44.563577" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_49">
      <g id="line2d_68">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="37.999694" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="37.999694" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_50">
      <g id="line2d_69">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="34.666694" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="34.666694" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_51">
      <g id="line2d_70">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="32.301893" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="32.301893" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_52">
      <g id="line2d_71">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="30.467611" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="30.467611" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_53">
      <g id="line2d_72">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="28.968894" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="28.968894" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_54">
      <g id="line2d_73">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="27.701746" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="27.701746" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_55">
      <g id="line2d_74">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="26.604093" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="26.604093" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_56">
      <g id="line2d_75">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="165.799615" y="25.635895" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="162.799375" y="25.635895" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_76">
-    <path d="M 165.799615 119.408224 
-L 185.316894 100.480542 
-L 204.834173 81.552859 
-L 224.351452 62.625177 
-L 243.868731 43.697494 
-L 263.38601 24.769811 
-" clip-path="url(#p3a99cd5ba9)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 162.799375 119.408224 
+L 182.316654 100.480542 
+L 201.833933 81.552859 
+L 221.351212 62.625177 
+L 240.868491 43.697494 
+L 260.38577 24.769811 
+" clip-path="url(#pc705a49e2d)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_20">
     <!-- SCALE.LOG -->
-    <g transform="translate(190.210547 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(187.210307 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-32" d="M 2828 2328 
 Q 2828 3356 2617 3797 
@@ -1191,22 +1191,22 @@ z
     </g>
    </g>
    <g id="patch_6">
-    <path d="M 165.799615 124.140145 
-L 165.799615 20.037891 
+    <path d="M 162.799375 124.140145 
+L 162.799375 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 165.799615 124.140145 
-L 263.38601 124.140145 
+    <path d="M 162.799375 124.140145 
+L 260.38577 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_3">
    <g id="patch_8">
-    <path d="M 288.20649 124.140145 
-L 385.792885 124.140145 
-L 385.792885 20.037891 
-L 288.20649 20.037891 
+    <path d="M 285.20625 124.140145 
+L 382.792645 124.140145 
+L 382.792645 20.037891 
+L 285.20625 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -1214,12 +1214,12 @@ z
     <g id="xtick_7">
      <g id="line2d_77">
       <g>
-       <use xlink:href="#m50cab8319e" x="288.20649" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="285.20625" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 0 -->
-      <g transform="translate(285.982115 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(282.981875 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -1227,12 +1227,12 @@ z
     <g id="xtick_8">
      <g id="line2d_78">
       <g>
-       <use xlink:href="#m50cab8319e" x="327.241048" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="324.240808" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 2 -->
-      <g transform="translate(325.016673 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(322.016433 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -1240,12 +1240,12 @@ z
     <g id="xtick_9">
      <g id="line2d_79">
       <g>
-       <use xlink:href="#m50cab8319e" x="366.275606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="363.275366" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 4 -->
-      <g transform="translate(364.051231 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(361.050991 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -1254,18 +1254,18 @@ z
    <g id="matplotlib.axis_6">
     <g id="ytick_57">
      <g id="line2d_80">
-      <path d="M 288.20649 119.408224 
-L 385.792885 119.408224 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 285.20625 119.408224 
+L 382.792645 119.408224 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_81">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="288.20649" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="285.20625" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(269.38649 123.048224) scale(0.08 -0.08)">
+      <g transform="translate(266.38625 123.048224) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.754688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.754688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(112.1875 42.054688) scale(0.7)"/>
@@ -1274,18 +1274,18 @@ L 385.792885 119.408224
     </g>
     <g id="ytick_58">
      <g id="line2d_82">
-      <path d="M 288.20649 96.813167 
-L 385.792885 96.813167 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 285.20625 96.813167 
+L 382.792645 96.813167 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_83">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="288.20649" y="96.813167" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="285.20625" y="96.813167" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(269.38649 100.453167) scale(0.08 -0.08)">
+      <g transform="translate(266.38625 100.453167) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.9625)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.9625)"/>
        <use xlink:href="#Helvetica-14" transform="translate(112.1875 42.2625) scale(0.7)"/>
@@ -1294,18 +1294,18 @@ L 385.792885 96.813167
     </g>
     <g id="ytick_59">
      <g id="line2d_84">
-      <path d="M 288.20649 78.802328 
-L 385.792885 78.802328 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 285.20625 78.802328 
+L 382.792645 78.802328 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_85">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="288.20649" y="78.802328" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="285.20625" y="78.802328" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(269.38649 82.442328) scale(0.08 -0.08)">
+      <g transform="translate(266.38625 82.442328) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.579688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.579688)"/>
        <use xlink:href="#Helvetica-15" transform="translate(112.1875 41.879688) scale(0.7)"/>
@@ -1314,18 +1314,18 @@ L 385.792885 78.802328
     </g>
     <g id="ytick_60">
      <g id="line2d_86">
-      <path d="M 288.20649 60.791489 
-L 385.792885 60.791489 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 285.20625 60.791489 
+L 382.792645 60.791489 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_87">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="288.20649" y="60.791489" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="285.20625" y="60.791489" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(269.38649 64.431489) scale(0.08 -0.08)">
+      <g transform="translate(266.38625 64.431489) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.689063)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.689063)"/>
        <use xlink:href="#Helvetica-16" transform="translate(112.1875 41.989063) scale(0.7)"/>
@@ -1334,18 +1334,18 @@ L 385.792885 60.791489
     </g>
     <g id="ytick_61">
      <g id="line2d_88">
-      <path d="M 288.20649 42.78065 
-L 385.792885 42.78065 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 285.20625 42.78065 
+L 382.792645 42.78065 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_89">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="288.20649" y="42.78065" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="285.20625" y="42.78065" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_28">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(269.38649 46.42065) scale(0.08 -0.08)">
+      <g transform="translate(266.38625 46.42065) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.6125)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.6125)"/>
        <use xlink:href="#Helvetica-17" transform="translate(112.1875 41.9125) scale(0.7)"/>
@@ -1354,18 +1354,18 @@ L 385.792885 42.78065
     </g>
     <g id="ytick_62">
      <g id="line2d_90">
-      <path d="M 288.20649 24.769811 
-L 385.792885 24.769811 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 285.20625 24.769811 
+L 382.792645 24.769811 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_91">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="288.20649" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="285.20625" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_29">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g transform="translate(269.38649 28.369811) scale(0.08 -0.08)">
+      <g transform="translate(266.38625 28.369811) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.575)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.575)"/>
        <use xlink:href="#Helvetica-18" transform="translate(112.1875 41.875) scale(0.7)"/>
@@ -1374,17 +1374,17 @@ L 385.792885 24.769811
     </g>
    </g>
    <g id="line2d_92">
-    <path d="M 288.20649 119.408224 
-L 307.723769 96.813167 
-L 327.241048 78.802328 
-L 346.758327 60.791489 
-L 366.275606 42.78065 
-L 385.792885 24.769811 
-" clip-path="url(#p4324388e45)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 285.20625 119.408224 
+L 304.723529 96.813167 
+L 324.240808 78.802328 
+L 343.758087 60.791489 
+L 363.275366 42.78065 
+L 382.792645 24.769811 
+" clip-path="url(#p0087cb9d70)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_30">
     <!-- SCALE.SYMLOG -->
-    <g transform="translate(304.49 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(301.48976 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-3c" d="M 116 4666 
 L 788 4666 
@@ -1430,22 +1430,22 @@ z
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 288.20649 124.140145 
-L 288.20649 20.037891 
+    <path d="M 285.20625 124.140145 
+L 285.20625 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_10">
-    <path d="M 288.20649 124.140145 
-L 385.792885 124.140145 
+    <path d="M 285.20625 124.140145 
+L 382.792645 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_4">
    <g id="patch_11">
-    <path d="M 410.613365 124.140145 
-L 508.19976 124.140145 
-L 508.19976 20.037891 
-L 410.613365 20.037891 
+    <path d="M 407.613125 124.140145 
+L 505.19952 124.140145 
+L 505.19952 20.037891 
+L 407.613125 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -1453,12 +1453,12 @@ z
     <g id="xtick_10">
      <g id="line2d_93">
       <g>
-       <use xlink:href="#m50cab8319e" x="410.613365" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="407.613125" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
       <!-- 0 -->
-      <g transform="translate(408.38899 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(405.38875 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -1466,12 +1466,12 @@ z
     <g id="xtick_11">
      <g id="line2d_94">
       <g>
-       <use xlink:href="#m50cab8319e" x="449.647923" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="446.647683" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_32">
       <!-- 2 -->
-      <g transform="translate(447.423548 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(444.423308 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -1479,12 +1479,12 @@ z
     <g id="xtick_12">
      <g id="line2d_95">
       <g>
-       <use xlink:href="#m50cab8319e" x="488.682481" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#mc655f1a076" x="485.682241" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
       <!-- 4 -->
-      <g transform="translate(486.458106 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(483.457866 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -1493,18 +1493,18 @@ z
    <g id="matplotlib.axis_8">
     <g id="ytick_63">
      <g id="line2d_96">
-      <path d="M 410.613365 119.408224 
-L 508.19976 119.408224 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 407.613125 119.408224 
+L 505.19952 119.408224 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_97">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="410.613365" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="407.613125" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
       <!-- $\mathdefault{10^{0}}$ -->
-      <g transform="translate(391.793365 123.048224) scale(0.08 -0.08)">
+      <g transform="translate(388.793125 123.048224) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.754688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.754688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(112.1875 42.054688) scale(0.7)"/>
@@ -1513,18 +1513,18 @@ L 508.19976 119.408224
     </g>
     <g id="ytick_64">
      <g id="line2d_98">
-      <path d="M 410.613365 101.718106 
-L 508.19976 101.718106 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 407.613125 101.718106 
+L 505.19952 101.718106 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_99">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="410.613365" y="101.718106" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="407.613125" y="101.718106" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
       <!-- $\mathdefault{10^{1}}$ -->
-      <g transform="translate(391.793365 105.358106) scale(0.08 -0.08)">
+      <g transform="translate(388.793125 105.358106) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.9625)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.9625)"/>
        <use xlink:href="#Helvetica-14" transform="translate(112.1875 42.2625) scale(0.7)"/>
@@ -1533,18 +1533,18 @@ L 508.19976 101.718106
     </g>
     <g id="ytick_65">
      <g id="line2d_100">
-      <path d="M 410.613365 82.496434 
-L 508.19976 82.496434 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 407.613125 82.496434 
+L 505.19952 82.496434 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_101">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="410.613365" y="82.496434" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="407.613125" y="82.496434" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_36">
       <!-- $\mathdefault{10^{2}}$ -->
-      <g transform="translate(391.793365 86.136434) scale(0.08 -0.08)">
+      <g transform="translate(388.793125 86.136434) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.579688)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.579688)"/>
        <use xlink:href="#Helvetica-15" transform="translate(112.1875 41.879688) scale(0.7)"/>
@@ -1553,18 +1553,18 @@ L 508.19976 82.496434
     </g>
     <g id="ytick_66">
      <g id="line2d_102">
-      <path d="M 410.613365 63.254364 
-L 508.19976 63.254364 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 407.613125 63.254364 
+L 505.19952 63.254364 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_103">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="410.613365" y="63.254364" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="407.613125" y="63.254364" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_37">
       <!-- $\mathdefault{10^{3}}$ -->
-      <g transform="translate(391.793365 66.894364) scale(0.08 -0.08)">
+      <g transform="translate(388.793125 66.894364) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.689063)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.689063)"/>
        <use xlink:href="#Helvetica-16" transform="translate(112.1875 41.989063) scale(0.7)"/>
@@ -1573,18 +1573,18 @@ L 508.19976 63.254364
     </g>
     <g id="ytick_67">
      <g id="line2d_104">
-      <path d="M 410.613365 44.012089 
-L 508.19976 44.012089 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 407.613125 44.012089 
+L 505.19952 44.012089 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_105">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="410.613365" y="44.012089" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="407.613125" y="44.012089" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_38">
       <!-- $\mathdefault{10^{4}}$ -->
-      <g transform="translate(391.793365 47.652089) scale(0.08 -0.08)">
+      <g transform="translate(388.793125 47.652089) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.6125)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.6125)"/>
        <use xlink:href="#Helvetica-17" transform="translate(112.1875 41.9125) scale(0.7)"/>
@@ -1593,18 +1593,18 @@ L 508.19976 44.012089
     </g>
     <g id="ytick_68">
      <g id="line2d_106">
-      <path d="M 410.613365 24.769811 
-L 508.19976 24.769811 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 407.613125 24.769811 
+L 505.19952 24.769811 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_107">
       <g>
-       <use xlink:href="#mc85c8f87f9" x="410.613365" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#me217b0e9ea" x="407.613125" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_39">
       <!-- $\mathdefault{10^{5}}$ -->
-      <g transform="translate(391.793365 28.369811) scale(0.08 -0.08)">
+      <g transform="translate(388.793125 28.369811) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14" transform="translate(0 0.575)"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.615234 0.575)"/>
        <use xlink:href="#Helvetica-18" transform="translate(112.1875 41.875) scale(0.7)"/>
@@ -1614,93 +1614,93 @@ L 508.19976 24.769811
     <g id="ytick_69">
      <g id="line2d_108">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="122.752302" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="122.752302" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_70">
      <g id="line2d_109">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="114.709506" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="114.709506" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_71">
      <g id="line2d_110">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="107.449081" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="107.449081" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_72">
      <g id="line2d_111">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="95.9412" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="95.9412" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_73">
      <g id="line2d_112">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="88.28831" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="88.28831" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_74">
      <g id="line2d_113">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="76.704088" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="76.704088" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_75">
      <g id="line2d_114">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="69.04686" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="69.04686" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_76">
      <g id="line2d_115">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="57.461863" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="57.461863" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_77">
      <g id="line2d_116">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="49.804591" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="49.804591" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_78">
      <g id="line2d_117">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="38.219586" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="38.219586" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
     <g id="ytick_79">
      <g id="line2d_118">
       <g>
-       <use xlink:href="#m0336e7fa9f" x="410.613365" y="30.562314" style="stroke: #000000; stroke-width: 0.6"/>
+       <use xlink:href="#mfd956b8d52" x="407.613125" y="30.562314" style="stroke: #000000; stroke-width: 0.6"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_119">
-    <path d="M 410.613365 119.408224 
-L 430.130644 101.718106 
-L 449.647923 82.496434 
-L 469.165202 63.254364 
-L 488.682481 44.012089 
-L 508.19976 24.769811 
-" clip-path="url(#pad4050efa4)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 407.613125 119.408224 
+L 427.130404 101.718106 
+L 446.647683 82.496434 
+L 466.164962 63.254364 
+L 485.682241 44.012089 
+L 505.19952 24.769811 
+" clip-path="url(#p9cbd068125)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_40">
     <!-- SCALE.ASINH -->
-    <g transform="translate(429.606016 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(426.605776 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-2b" d="M 428 4666 
 L 1063 4666 
@@ -1732,19 +1732,19 @@ z
     </g>
    </g>
    <g id="patch_12">
-    <path d="M 410.613365 124.140145 
-L 410.613365 20.037891 
+    <path d="M 407.613125 124.140145 
+L 407.613125 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_13">
-    <path d="M 410.613365 124.140145 
-L 508.19976 124.140145 
+    <path d="M 407.613125 124.140145 
+L 505.19952 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_41">
    <!-- Same growth data on each value axis; SYMLOG and ASINH also accept zero and negative values. -->
-   <g transform="translate(7.2 145.10376) scale(0.085 -0.085)">
+   <g transform="translate(49.452533 156.83976) scale(0.085 -0.085)">
     <defs>
      <path id="DejaVuSans-Oblique-36" d="M 3859 4513 
 L 3738 3897 
@@ -2517,17 +2517,17 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p5d6a8f26ac">
-   <rect x="43.39274" y="20.037891" width="97.586395" height="104.102254"/>
+  <clipPath id="pb74072fc43">
+   <rect x="40.3925" y="20.037891" width="97.586395" height="104.102254"/>
   </clipPath>
-  <clipPath id="p3a99cd5ba9">
-   <rect x="165.799615" y="20.037891" width="97.586395" height="104.102254"/>
+  <clipPath id="pc705a49e2d">
+   <rect x="162.799375" y="20.037891" width="97.586395" height="104.102254"/>
   </clipPath>
-  <clipPath id="p4324388e45">
-   <rect x="288.20649" y="20.037891" width="97.586395" height="104.102254"/>
+  <clipPath id="p0087cb9d70">
+   <rect x="285.20625" y="20.037891" width="97.586395" height="104.102254"/>
   </clipPath>
-  <clipPath id="pad4050efa4">
-   <rect x="410.613365" y="20.037891" width="97.586395" height="104.102254"/>
+  <clipPath id="p9cbd068125">
+   <rect x="407.613125" y="20.037891" width="97.586395" height="104.102254"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/imgs/const-show-grid.svg
+++ b/docs/assets/imgs/const-show-grid.svg
@@ -1,0 +1,2066 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="154.345752pt" viewBox="0 0 515.39976 154.345752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-08-23T23:34:25.692049</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.11.1, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 154.345752 
+L 515.39976 154.345752 
+L 515.39976 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 21.14899 124.140145 
+L 130.19976 124.140145 
+L 130.19976 20.037891 
+L 21.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m4289229a36" d="M 0 0 
+L 0 3 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m4289229a36" x="21.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- 0 -->
+      <g transform="translate(18.924615 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-13" d="M 1731 4475 
+Q 2600 4475 2988 3759 
+Q 3288 3206 3288 2244 
+Q 3288 1331 3016 734 
+Q 2622 -122 1728 -122 
+Q 922 -122 528 578 
+Q 200 1163 200 2147 
+Q 200 2909 397 3456 
+Q 766 4475 1731 4475 
+z
+M 1725 391 
+Q 2163 391 2422 778 
+Q 2681 1166 2681 2222 
+Q 2681 2984 2493 3476 
+Q 2306 3969 1766 3969 
+Q 1269 3969 1039 3501 
+Q 809 3034 809 2125 
+Q 809 1441 956 1025 
+Q 1181 391 1725 391 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m4289229a36" x="64.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- 2 -->
+      <g transform="translate(62.544923 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-15" d="M 200 0 
+Q 231 578 439 1006 
+Q 647 1434 1250 1784 
+L 1850 2131 
+Q 2253 2366 2416 2531 
+Q 2672 2791 2672 3125 
+Q 2672 3516 2437 3745 
+Q 2203 3975 1813 3975 
+Q 1234 3975 1013 3538 
+Q 894 3303 881 2888 
+L 309 2888 
+Q 319 3472 525 3841 
+Q 891 4491 1816 4491 
+Q 2584 4491 2939 4075 
+Q 3294 3659 3294 3150 
+Q 3294 2613 2916 2231 
+Q 2697 2009 2131 1694 
+L 1703 1456 
+Q 1397 1288 1222 1134 
+Q 909 863 828 531 
+L 3272 531 
+L 3272 0 
+L 200 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m4289229a36" x="108.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- 4 -->
+      <g transform="translate(106.165231 136.640145) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-17" d="M 2116 1584 
+L 2116 3613 
+L 681 1584 
+L 2116 1584 
+z
+M 2125 0 
+L 2125 1094 
+L 163 1094 
+L 163 1644 
+L 2213 4488 
+L 2688 4488 
+L 2688 1584 
+L 3347 1584 
+L 3347 1094 
+L 2688 1094 
+L 2688 0 
+L 2125 0 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_4">
+      <defs>
+       <path id="m580e7cc064" d="M 0 0 
+L -3 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m580e7cc064" x="21.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- 1 -->
+      <g transform="translate(10.20024 122.408224) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-14" d="M 613 3169 
+L 613 3600 
+Q 1222 3659 1462 3798 
+Q 1703 3938 1822 4456 
+L 2266 4456 
+L 2266 0 
+L 1666 0 
+L 1666 3169 
+L 613 3169 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m580e7cc064" x="21.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- 2 -->
+      <g transform="translate(10.20024 103.480542) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m580e7cc064" x="21.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 3 -->
+      <g transform="translate(10.20024 84.552859) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-16" d="M 1663 -122 
+Q 869 -122 511 314 
+Q 153 750 153 1375 
+L 741 1375 
+Q 778 941 903 744 
+Q 1122 391 1694 391 
+Q 2138 391 2406 628 
+Q 2675 866 2675 1241 
+Q 2675 1703 2392 1887 
+Q 2109 2072 1606 2072 
+Q 1550 2072 1492 2070 
+Q 1434 2069 1375 2066 
+L 1375 2563 
+Q 1463 2553 1522 2550 
+Q 1581 2547 1650 2547 
+Q 1966 2547 2169 2647 
+Q 2525 2822 2525 3272 
+Q 2525 3606 2287 3787 
+Q 2050 3969 1734 3969 
+Q 1172 3969 956 3594 
+Q 838 3388 822 3006 
+L 266 3006 
+Q 266 3506 466 3856 
+Q 809 4481 1675 4481 
+Q 2359 4481 2734 4176 
+Q 3109 3872 3109 3294 
+Q 3109 2881 2888 2625 
+Q 2750 2466 2531 2375 
+Q 2884 2278 3082 2001 
+Q 3281 1725 3281 1325 
+Q 3281 684 2859 281 
+Q 2438 -122 1663 -122 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m580e7cc064" x="21.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 4 -->
+      <g transform="translate(10.20024 65.625177) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m580e7cc064" x="21.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 5 -->
+      <g transform="translate(10.20024 46.697494) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-18" d="M 791 1141 
+Q 847 659 1238 475 
+Q 1438 381 1700 381 
+Q 2200 381 2440 700 
+Q 2681 1019 2681 1406 
+Q 2681 1875 2395 2131 
+Q 2109 2388 1709 2388 
+Q 1419 2388 1211 2275 
+Q 1003 2163 856 1963 
+L 369 1991 
+L 709 4400 
+L 3034 4400 
+L 3034 3856 
+L 1131 3856 
+L 941 2613 
+Q 1097 2731 1238 2791 
+Q 1488 2894 1816 2894 
+Q 2431 2894 2859 2497 
+Q 3288 2100 3288 1491 
+Q 3288 856 2895 371 
+Q 2503 -113 1644 -113 
+Q 1097 -113 676 195 
+Q 256 503 206 1141 
+L 791 1141 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m580e7cc064" x="21.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 6 -->
+      <g transform="translate(10.20024 27.769811) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_10">
+    <path d="M 21.14899 119.408224 
+L 42.959144 81.552859 
+L 64.769298 100.480542 
+L 86.579452 43.697494 
+L 108.389606 62.625177 
+L 130.19976 24.769811 
+" clip-path="url(#p6b60c44216)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_10">
+    <!-- SHOW_GRID.NONE -->
+    <g transform="translate(37.746406 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-36" d="M 3163 4506 
+L 3163 3866 
+Q 2875 4050 2586 4144 
+Q 2297 4238 2003 4238 
+Q 1556 4238 1297 4030 
+Q 1038 3822 1038 3469 
+Q 1038 3159 1208 2996 
+Q 1378 2834 1844 2725 
+L 2175 2650 
+Q 2831 2497 3131 2169 
+Q 3431 1841 3431 1275 
+Q 3431 609 3018 259 
+Q 2606 -91 1819 -91 
+Q 1491 -91 1159 -20 
+Q 828 50 494 191 
+L 494 863 
+Q 853 634 1173 528 
+Q 1494 422 1819 422 
+Q 2297 422 2562 636 
+Q 2828 850 2828 1234 
+Q 2828 1584 2645 1768 
+Q 2463 1953 2009 2053 
+L 1672 2131 
+Q 1022 2278 728 2575 
+Q 434 2872 434 3372 
+Q 434 3997 854 4373 
+Q 1275 4750 1972 4750 
+Q 2241 4750 2537 4689 
+Q 2834 4628 3163 4506 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2b" d="M 428 4666 
+L 1063 4666 
+L 1063 2753 
+L 2791 2753 
+L 2791 4666 
+L 3425 4666 
+L 3425 0 
+L 2791 0 
+L 2791 2222 
+L 1063 2222 
+L 1063 0 
+L 428 0 
+L 428 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-32" d="M 2828 2328 
+Q 2828 3356 2617 3797 
+Q 2406 4238 1925 4238 
+Q 1447 4238 1236 3797 
+Q 1025 3356 1025 2328 
+Q 1025 1303 1236 862 
+Q 1447 422 1925 422 
+Q 2406 422 2617 861 
+Q 2828 1300 2828 2328 
+z
+M 3488 2328 
+Q 3488 1109 3102 509 
+Q 2716 -91 1925 -91 
+Q 1134 -91 750 506 
+Q 366 1103 366 2328 
+Q 366 3550 752 4150 
+Q 1138 4750 1925 4750 
+Q 2716 4750 3102 4150 
+Q 3488 3550 3488 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-3a" d="M 0 4666 
+L 616 4666 
+L 1063 878 
+L 1594 3384 
+L 2253 3384 
+L 2791 872 
+L 3238 4666 
+L 3853 4666 
+L 3156 0 
+L 2559 0 
+L 1925 2772 
+L 1294 0 
+L 697 0 
+L 0 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-42" d="M 3853 -1259 
+L 3853 -1509 
+L 0 -1509 
+L 0 -1259 
+L 3853 -1259 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2a" d="M 3450 384 
+Q 3197 150 2880 29 
+Q 2563 -91 2194 -91 
+Q 1306 -91 812 545 
+Q 319 1181 319 2328 
+Q 319 3472 819 4111 
+Q 1319 4750 2209 4750 
+Q 2503 4750 2772 4667 
+Q 3041 4584 3291 4416 
+L 3291 3769 
+Q 3038 4009 2772 4123 
+Q 2506 4238 2209 4238 
+Q 1594 4238 1286 3761 
+Q 978 3284 978 2328 
+Q 978 1356 1276 889 
+Q 1575 422 2194 422 
+Q 2403 422 2561 470 
+Q 2719 519 2847 622 
+L 2847 1875 
+L 2169 1875 
+L 2169 2394 
+L 3450 2394 
+L 3450 384 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-35" d="M 2375 2203 
+Q 2619 2141 2791 1967 
+Q 2963 1794 3219 1275 
+L 3853 0 
+L 3175 0 
+L 2619 1178 
+Q 2378 1681 2186 1826 
+Q 1994 1972 1684 1972 
+L 1081 1972 
+L 1081 0 
+L 447 0 
+L 447 4666 
+L 1747 4666 
+Q 2516 4666 2925 4319 
+Q 3334 3972 3334 3316 
+Q 3334 2853 3082 2561 
+Q 2831 2269 2375 2203 
+z
+M 1081 4147 
+L 1081 2491 
+L 1772 2491 
+Q 2225 2491 2447 2694 
+Q 2669 2897 2669 3316 
+Q 2669 3719 2433 3933 
+Q 2197 4147 1747 4147 
+L 1081 4147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-2c" d="M 628 4666 
+L 3219 4666 
+L 3219 4134 
+L 2241 4134 
+L 2241 531 
+L 3219 531 
+L 3219 0 
+L 628 0 
+L 628 531 
+L 1606 531 
+L 1606 4134 
+L 628 4134 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-27" d="M 1363 519 
+Q 2159 519 2475 911 
+Q 2791 1303 2791 2328 
+Q 2791 3363 2477 3755 
+Q 2163 4147 1363 4147 
+L 1063 4147 
+L 1063 519 
+L 1363 519 
+z
+M 1375 4666 
+Q 2444 4666 2950 4097 
+Q 3456 3528 3456 2328 
+Q 3456 1134 2950 567 
+Q 2444 0 1375 0 
+L 428 0 
+L 428 4666 
+L 1375 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-11" d="M 1528 953 
+L 2316 953 
+L 2316 0 
+L 1528 0 
+L 1528 953 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-31" d="M 434 4666 
+L 1234 4666 
+L 2809 825 
+L 2809 4666 
+L 3419 4666 
+L 3419 0 
+L 2619 0 
+L 1044 3841 
+L 1044 0 
+L 434 0 
+L 434 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-28" d="M 616 4666 
+L 3384 4666 
+L 3384 4134 
+L 1247 4134 
+L 1247 2753 
+L 3291 2753 
+L 3291 2222 
+L 1247 2222 
+L 1247 531 
+L 3444 531 
+L 3444 0 
+L 616 0 
+L 616 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-3a" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-31" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+    </g>
+   </g>
+   <g id="patch_3">
+    <path d="M 21.14899 124.140145 
+L 21.14899 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 21.14899 124.140145 
+L 130.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_2">
+   <g id="patch_5">
+    <path d="M 147.14899 124.140145 
+L 256.19976 124.140145 
+L 256.19976 20.037891 
+L 147.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_3">
+    <g id="xtick_4">
+     <g id="line2d_11">
+      <path d="M 147.14899 124.140145 
+L 147.14899 20.037891 
+" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m4289229a36" x="147.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 0 -->
+      <g transform="translate(144.924615 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_13">
+      <path d="M 190.769298 124.140145 
+L 190.769298 20.037891 
+" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m4289229a36" x="190.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 2 -->
+      <g transform="translate(188.544923 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_15">
+      <path d="M 234.389606 124.140145 
+L 234.389606 20.037891 
+" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m4289229a36" x="234.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 4 -->
+      <g transform="translate(232.165231 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_4">
+    <g id="ytick_7">
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m580e7cc064" x="147.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 1 -->
+      <g transform="translate(136.20024 122.408224) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m580e7cc064" x="147.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 2 -->
+      <g transform="translate(136.20024 103.480542) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_9">
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m580e7cc064" x="147.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 3 -->
+      <g transform="translate(136.20024 84.552859) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_10">
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m580e7cc064" x="147.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 4 -->
+      <g transform="translate(136.20024 65.625177) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_11">
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#m580e7cc064" x="147.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_18">
+      <!-- 5 -->
+      <g transform="translate(136.20024 46.697494) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_12">
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m580e7cc064" x="147.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_19">
+      <!-- 6 -->
+      <g transform="translate(136.20024 27.769811) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_23">
+    <path d="M 147.14899 119.408224 
+L 168.959144 81.552859 
+L 190.769298 100.480542 
+L 212.579452 43.697494 
+L 234.389606 62.625177 
+L 256.19976 24.769811 
+" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_20">
+    <!-- SHOW_GRID.X -->
+    <g transform="translate(171.873828 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-3b" d="M 269 4666 
+L 947 4666 
+L 1972 2906 
+L 3016 4666 
+L 3694 4666 
+L 2297 2472 
+L 3794 0 
+L 3116 0 
+L 1972 2009 
+L 738 0 
+L 56 0 
+L 1619 2472 
+L 269 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-3a" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3b" transform="translate(602.03125 0)"/>
+    </g>
+   </g>
+   <g id="patch_6">
+    <path d="M 147.14899 124.140145 
+L 147.14899 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 147.14899 124.140145 
+L 256.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_8">
+    <path d="M 273.14899 124.140145 
+L 382.19976 124.140145 
+L 382.19976 20.037891 
+L 273.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_7">
+     <g id="line2d_24">
+      <g>
+       <use xlink:href="#m4289229a36" x="273.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_21">
+      <!-- 0 -->
+      <g transform="translate(270.924615 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#m4289229a36" x="316.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_22">
+      <!-- 2 -->
+      <g transform="translate(314.544923 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_26">
+      <g>
+       <use xlink:href="#m4289229a36" x="360.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_23">
+      <!-- 4 -->
+      <g transform="translate(358.165231 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_13">
+     <g id="line2d_27">
+      <path d="M 273.14899 119.408224 
+L 382.19976 119.408224 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_28">
+      <g>
+       <use xlink:href="#m580e7cc064" x="273.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_24">
+      <!-- 1 -->
+      <g transform="translate(262.20024 122.408224) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_29">
+      <path d="M 273.14899 100.480542 
+L 382.19976 100.480542 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_30">
+      <g>
+       <use xlink:href="#m580e7cc064" x="273.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_25">
+      <!-- 2 -->
+      <g transform="translate(262.20024 103.480542) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_31">
+      <path d="M 273.14899 81.552859 
+L 382.19976 81.552859 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_32">
+      <g>
+       <use xlink:href="#m580e7cc064" x="273.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_26">
+      <!-- 3 -->
+      <g transform="translate(262.20024 84.552859) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_33">
+      <path d="M 273.14899 62.625177 
+L 382.19976 62.625177 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_34">
+      <g>
+       <use xlink:href="#m580e7cc064" x="273.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- 4 -->
+      <g transform="translate(262.20024 65.625177) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_35">
+      <path d="M 273.14899 43.697494 
+L 382.19976 43.697494 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_36">
+      <g>
+       <use xlink:href="#m580e7cc064" x="273.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- 5 -->
+      <g transform="translate(262.20024 46.697494) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_37">
+      <path d="M 273.14899 24.769811 
+L 382.19976 24.769811 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m580e7cc064" x="273.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 6 -->
+      <g transform="translate(262.20024 27.769811) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_39">
+    <path d="M 273.14899 119.408224 
+L 294.959144 81.552859 
+L 316.769298 100.480542 
+L 338.579452 43.697494 
+L 360.389606 62.625177 
+L 382.19976 24.769811 
+" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_30">
+    <!-- SHOW_GRID.Y -->
+    <g transform="translate(297.873828 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-3c" d="M 116 4666 
+L 788 4666 
+L 1925 2606 
+L 3059 4666 
+L 3738 4666 
+L 2241 2094 
+L 2241 0 
+L 1606 0 
+L 1606 2094 
+L 116 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-3a" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(602.03125 0)"/>
+    </g>
+   </g>
+   <g id="patch_9">
+    <path d="M 273.14899 124.140145 
+L 273.14899 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 273.14899 124.140145 
+L 382.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_4">
+   <g id="patch_11">
+    <path d="M 399.14899 124.140145 
+L 508.19976 124.140145 
+L 508.19976 20.037891 
+L 399.14899 20.037891 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_10">
+     <g id="line2d_40">
+      <path d="M 399.14899 124.140145 
+L 399.14899 20.037891 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m4289229a36" x="399.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 0 -->
+      <g transform="translate(396.924615 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_11">
+     <g id="line2d_42">
+      <path d="M 442.769298 124.140145 
+L 442.769298 20.037891 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_43">
+      <g>
+       <use xlink:href="#m4289229a36" x="442.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 2 -->
+      <g transform="translate(440.544923 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_12">
+     <g id="line2d_44">
+      <path d="M 486.389606 124.140145 
+L 486.389606 20.037891 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_45">
+      <g>
+       <use xlink:href="#m4289229a36" x="486.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 4 -->
+      <g transform="translate(484.165231 136.640145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_19">
+     <g id="line2d_46">
+      <path d="M 399.14899 119.408224 
+L 508.19976 119.408224 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_47">
+      <g>
+       <use xlink:href="#m580e7cc064" x="399.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 1 -->
+      <g transform="translate(388.20024 122.408224) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_48">
+      <path d="M 399.14899 100.480542 
+L 508.19976 100.480542 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_49">
+      <g>
+       <use xlink:href="#m580e7cc064" x="399.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 2 -->
+      <g transform="translate(388.20024 103.480542) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_50">
+      <path d="M 399.14899 81.552859 
+L 508.19976 81.552859 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_51">
+      <g>
+       <use xlink:href="#m580e7cc064" x="399.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 3 -->
+      <g transform="translate(388.20024 84.552859) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_52">
+      <path d="M 399.14899 62.625177 
+L 508.19976 62.625177 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_53">
+      <g>
+       <use xlink:href="#m580e7cc064" x="399.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 4 -->
+      <g transform="translate(388.20024 65.625177) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_23">
+     <g id="line2d_54">
+      <path d="M 399.14899 43.697494 
+L 508.19976 43.697494 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m580e7cc064" x="399.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 5 -->
+      <g transform="translate(388.20024 46.697494) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_24">
+     <g id="line2d_56">
+      <path d="M 399.14899 24.769811 
+L 508.19976 24.769811 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m580e7cc064" x="399.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_39">
+      <!-- 6 -->
+      <g transform="translate(388.20024 27.769811) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-19"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="line2d_58">
+    <path d="M 399.14899 119.408224 
+L 420.959144 81.552859 
+L 442.769298 100.480542 
+L 464.579452 43.697494 
+L 486.389606 62.625177 
+L 508.19976 24.769811 
+" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+   </g>
+   <g id="text_40">
+    <!-- SHOW_GRID.BOTH -->
+    <g transform="translate(415.746406 14.037891) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-25" d="M 1153 2228 
+L 1153 519 
+L 1900 519 
+Q 2450 519 2684 711 
+Q 2919 903 2919 1344 
+Q 2919 1800 2672 2014 
+Q 2425 2228 1900 2228 
+L 1153 2228 
+z
+M 1153 4147 
+L 1153 2741 
+L 1888 2741 
+Q 2344 2741 2548 2916 
+Q 2753 3091 2753 3481 
+Q 2753 3834 2551 3990 
+Q 2350 4147 1888 4147 
+L 1153 4147 
+z
+M 519 4666 
+L 1900 4666 
+Q 2616 4666 3003 4356 
+Q 3391 4047 3391 3481 
+Q 3391 3053 3186 2806 
+Q 2981 2559 2572 2497 
+Q 3031 2428 3292 2104 
+Q 3553 1781 3553 1281 
+Q 3553 647 3137 323 
+Q 2722 0 1900 0 
+L 519 0 
+L 519 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-37" d="M 147 4666 
+L 3706 4666 
+L 3706 4134 
+L 2247 4134 
+L 2247 0 
+L 1613 0 
+L 1613 4134 
+L 147 4134 
+L 147 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-36"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-3a" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-27" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-25" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-2b" transform="translate(782.640625 0)"/>
+    </g>
+   </g>
+   <g id="patch_12">
+    <path d="M 399.14899 124.140145 
+L 399.14899 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 399.14899 124.140145 
+L 508.19976 124.140145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_41">
+   <!-- Grid lines darkened for visibility; when show_grid is unset or NONE, the theme's chart_default_show_grid fills in. -->
+   <g transform="translate(7.2 145.10376) scale(0.085 -0.085)">
+    <defs>
+     <path id="DejaVuSans-Oblique-2a" d="M 3494 697 
+L 3738 1919 
+L 2700 1919 
+L 2797 2438 
+L 4453 2438 
+L 4050 384 
+Q 3634 156 3143 32 
+Q 2653 -91 2156 -91 
+Q 1278 -91 783 396 
+Q 288 884 288 1753 
+Q 288 2475 589 3126 
+Q 891 3778 1422 4213 
+Q 1756 4484 2153 4617 
+Q 2550 4750 3034 4750 
+Q 3472 4750 3873 4639 
+Q 4275 4528 4641 4306 
+L 4513 3634 
+Q 4231 3928 3853 4083 
+Q 3475 4238 3047 4238 
+Q 2550 4238 2172 4048 
+Q 1794 3859 1497 3463 
+Q 1244 3125 1098 2667 
+Q 953 2209 953 1734 
+Q 953 1081 1287 751 
+Q 1622 422 2284 422 
+Q 2616 422 2925 492 
+Q 3234 563 3494 697 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
+L 1606 4134 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
+L 1747 4863 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
+L 3047 0 
+L 2472 0 
+L 2578 531 
+Q 2325 219 2001 64 
+Q 1678 -91 1281 -91 
+Q 834 -91 548 182 
+Q 263 456 263 884 
+Q 263 1497 752 1853 
+Q 1241 2209 2100 2209 
+L 2900 2209 
+L 2931 2363 
+Q 2938 2388 2941 2417 
+Q 2944 2447 2944 2509 
+Q 2944 2788 2717 2942 
+Q 2491 3097 2081 3097 
+Q 1800 3097 1504 3025 
+Q 1209 2953 897 2809 
+L 997 3341 
+Q 1322 3463 1633 3523 
+Q 1944 3584 2234 3584 
+Q 2853 3584 3176 3315 
+Q 3500 3047 3500 2534 
+Q 3500 2431 3484 2292 
+Q 3469 2153 3438 1997 
+z
+M 2816 1759 
+L 2241 1759 
+Q 1534 1759 1195 1570 
+Q 856 1381 856 984 
+Q 856 709 1029 553 
+Q 1203 397 1509 397 
+Q 1978 397 2328 733 
+Q 2678 1069 2791 1631 
+L 2816 1759 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4e" d="M 1172 4863 
+L 1747 4863 
+L 1197 2028 
+L 3169 3500 
+L 3916 3500 
+L 1716 1825 
+L 3322 0 
+L 2625 0 
+L 1131 1709 
+L 800 0 
+L 225 0 
+L 1172 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-49" d="M 3059 4863 
+L 2969 4384 
+L 2419 4384 
+Q 2106 4384 1964 4261 
+Q 1822 4138 1753 3809 
+L 1691 3500 
+L 2638 3500 
+L 2553 3053 
+L 1606 3053 
+L 1013 0 
+L 434 0 
+L 1031 3053 
+L 481 3053 
+L 563 3500 
+L 1113 3500 
+L 1159 3744 
+Q 1278 4363 1576 4613 
+Q 1875 4863 2516 4863 
+L 3059 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-59" d="M 459 3500 
+L 1069 3500 
+L 1581 525 
+L 3256 3500 
+L 3866 3500 
+L 1875 0 
+L 1100 0 
+L 459 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-45" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
+z
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
+L 806 0 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5c" d="M 1588 -325 
+Q 1188 -997 936 -1164 
+Q 684 -1331 294 -1331 
+L -159 -1331 
+L -63 -850 
+L 269 -850 
+Q 509 -850 678 -719 
+Q 847 -588 1056 -206 
+L 1234 128 
+L 459 3500 
+L 1069 3500 
+L 1650 819 
+L 3256 3500 
+L 3859 3500 
+L 1588 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5a" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-42" d="M 3263 -1063 
+L 3263 -1509 
+L -63 -1509 
+L -63 -1063 
+L 3263 -1063 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
+L 3219 434 
+Q 3047 -456 2561 -893 
+Q 2075 -1331 1253 -1331 
+Q 950 -1331 690 -1286 
+Q 431 -1241 206 -1147 
+L 313 -588 
+Q 525 -725 762 -790 
+Q 1000 -856 1269 -856 
+Q 1816 -856 2167 -557 
+Q 2519 -259 2631 300 
+L 2681 563 
+Q 2441 288 2122 144 
+Q 1803 0 1434 0 
+Q 903 0 598 351 
+Q 294 703 294 1319 
+Q 294 1803 478 2267 
+Q 663 2731 997 3091 
+Q 1219 3328 1514 3456 
+Q 1809 3584 2131 3584 
+Q 2484 3584 2746 3420 
+Q 3009 3256 3138 2956 
+L 3238 3500 
+L 3816 3500 
+z
+M 2950 2216 
+Q 2950 2641 2750 2872 
+Q 2550 3103 2181 3103 
+Q 1953 3103 1747 3012 
+Q 1541 2922 1394 2759 
+Q 1156 2491 1023 2127 
+Q 891 1763 891 1375 
+Q 891 944 1092 712 
+Q 1294 481 1672 481 
+Q 2219 481 2584 976 
+Q 2950 1472 2950 2216 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-58" d="M 428 1388 
+L 838 3500 
+L 1416 3500 
+L 1006 1409 
+Q 975 1256 961 1147 
+Q 947 1038 947 966 
+Q 947 700 1109 554 
+Q 1272 409 1569 409 
+Q 2031 409 2368 721 
+Q 2706 1034 2809 1563 
+L 3194 3500 
+L 3769 3500 
+L 3091 0 
+L 2516 0 
+L 2631 550 
+Q 2388 244 2052 76 
+Q 1716 -91 1338 -91 
+Q 878 -91 622 161 
+Q 366 413 366 863 
+Q 366 956 381 1097 
+Q 397 1238 428 1388 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-31" d="M 1081 4666 
+L 1931 4666 
+L 3219 666 
+L 4000 4666 
+L 4616 4666 
+L 3706 0 
+L 2853 0 
+L 1569 4025 
+L 788 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-32" d="M 2919 4238 
+Q 2400 4238 2003 3986 
+Q 1606 3734 1313 3219 
+Q 1125 2891 1026 2522 
+Q 928 2153 928 1778 
+Q 928 1128 1239 775 
+Q 1550 422 2119 422 
+Q 2631 422 3032 676 
+Q 3434 931 3719 1434 
+Q 3909 1772 4009 2142 
+Q 4109 2513 4109 2881 
+Q 4109 3528 3796 3883 
+Q 3484 4238 2919 4238 
+z
+M 2100 -91 
+Q 1241 -91 748 418 
+Q 256 928 256 1813 
+Q 256 2319 448 2847 
+Q 641 3375 978 3788 
+Q 1375 4272 1862 4511 
+Q 2350 4750 2938 4750 
+Q 3794 4750 4287 4245 
+Q 4781 3741 4781 2869 
+Q 4781 2331 4593 1812 
+Q 4406 1294 4056 872 
+Q 3656 384 3173 146 
+Q 2691 -91 2100 -91 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-28" d="M 1081 4666 
+L 4031 4666 
+L 3928 4134 
+L 1606 4134 
+L 1338 2753 
+L 3566 2753 
+L 3463 2222 
+L 1234 2222 
+L 909 531 
+L 3284 531 
+L 3181 0 
+L 172 0 
+L 1081 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-f" d="M 575 794 
+L 1234 794 
+L 1131 256 
+L 422 -744 
+L 19 -744 
+L 469 256 
+L 575 794 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
+L 5338 0 
+L 4763 0 
+L 5166 2094 
+Q 5191 2228 5203 2325 
+Q 5216 2422 5216 2491 
+Q 5216 2772 5059 2928 
+Q 4903 3084 4622 3084 
+Q 4203 3084 3875 2770 
+Q 3547 2456 3450 1953 
+L 3066 0 
+L 2491 0 
+L 2900 2094 
+Q 2925 2209 2937 2307 
+Q 2950 2406 2950 2484 
+Q 2950 2769 2794 2926 
+Q 2638 3084 2363 3084 
+Q 1938 3084 1609 2770 
+Q 1281 2456 1184 1953 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1609 3263 1923 3423 
+Q 2238 3584 2597 3584 
+Q 2978 3584 3223 3384 
+Q 3469 3184 3519 2828 
+Q 3781 3197 4126 3390 
+Q 4472 3584 4856 3584 
+Q 5306 3584 5551 3325 
+Q 5797 3066 5797 2591 
+Q 5797 2488 5784 2364 
+Q 5772 2241 5747 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-a" d="M 1147 4666 
+L 1147 2931 
+L 616 2931 
+L 616 4666 
+L 1147 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
+L 3316 2797 
+Q 3109 2947 2876 3022 
+Q 2644 3097 2394 3097 
+Q 2119 3097 1870 3000 
+Q 1622 2903 1453 2725 
+Q 1184 2453 1037 2087 
+Q 891 1722 891 1331 
+Q 891 859 1127 628 
+Q 1363 397 1844 397 
+Q 2081 397 2348 469 
+Q 2616 541 2906 684 
+L 2797 116 
+Q 2547 13 2283 -39 
+Q 2019 -91 1741 -91 
+Q 1044 -91 669 257 
+Q 294 606 294 1253 
+Q 294 1797 489 2255 
+Q 684 2713 1069 3078 
+Q 1331 3328 1684 3456 
+Q 2038 3584 2456 3584 
+Q 2700 3584 2940 3529 
+Q 3181 3475 3431 3366 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-127c" d="M 3525 4863 
+L 4103 4863 
+L 3963 4134 
+L 3384 4134 
+L 3525 4863 
+z
+M 3059 4863 
+L 2969 4384 
+L 2419 4384 
+Q 2106 4384 1964 4261 
+Q 1822 4138 1753 3809 
+L 1691 3500 
+L 3841 3500 
+L 3156 0 
+L 2578 0 
+L 3188 3056 
+L 1606 3056 
+L 1013 0 
+L 434 0 
+L 1031 3053 
+L 481 3053 
+L 563 3500 
+L 1113 3500 
+L 1159 3744 
+Q 1278 4363 1575 4613 
+Q 1875 4863 2516 4863 
+L 3059 4863 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-11" d="M 525 794 
+L 1184 794 
+L 1031 0 
+L 372 0 
+L 525 794 
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-Oblique-2a"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(77.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(118.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(146.375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(209.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(241.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(269.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(297.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(360.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(422.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(474.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(505.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(569.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(630.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4e" transform="translate(671.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(729.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(791.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(854.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(916.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(979.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-49" transform="translate(1011.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1046.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1107.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1148.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(1180.75 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1239.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1267.71875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1319.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-45" transform="translate(1347.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1411.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(1438.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1466.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(1494.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(1533.625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(1592.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1626.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(1658.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1740.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1803.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(1864.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1928.34375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1960.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(2012.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(2075.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(2136.78125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(2218.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(2268.5625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2332.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(2373.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(2400.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2464.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(2496.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2523.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2576.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(2607.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(2671.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2734.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2786.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2848.234375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2887.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(2919.21875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2980.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3021.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(3053.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-32" transform="translate(3128.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-31" transform="translate(3206.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(3281.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-f" transform="translate(3344.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3376.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3408.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3447.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3510.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3572.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3604.28125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3643.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3706.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(3768.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3865.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-a" transform="translate(3927.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3954.8125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4006.90625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(4038.6875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(4093.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(4157.046875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(4218.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(4259.4375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(4298.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(4348.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4412.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-49" transform="translate(4473.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(4508.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-58" transform="translate(4570.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4633.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(4661.296875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(4700.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(4750.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(4802.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4865.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(4927.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(5008.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(5058.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(5122.421875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(5163.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(5191.3125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5254.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-127c" transform="translate(5286.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(5351.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(5378.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(5406.734375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5458.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(5490.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(5518.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(5581.765625 0)"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p6b60c44216">
+   <rect x="21.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  </clipPath>
+  <clipPath id="pc7a306778e">
+   <rect x="147.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  </clipPath>
+  <clipPath id="pb3d71ea9f2">
+   <rect x="273.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  </clipPath>
+  <clipPath id="pc09d51b53a">
+   <rect x="399.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/assets/imgs/const-show-grid.svg
+++ b/docs/assets/imgs/const-show-grid.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="515.39976pt" height="154.345752pt" viewBox="0 0 515.39976 154.345752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="166.081752pt" viewBox="0 0 512.39952 166.081752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:34:25.692049</dc:date>
+    <dc:date>2026-08-23T23:46:43.416715</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -21,19 +21,19 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 154.345752 
-L 515.39976 154.345752 
-L 515.39976 0 
+   <path d="M 0 166.081752 
+L 512.39952 166.081752 
+L 512.39952 0 
 L 0 0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 21.14899 124.140145 
-L 130.19976 124.140145 
-L 130.19976 20.037891 
-L 21.14899 20.037891 
+    <path d="M 18.14875 124.140145 
+L 127.19952 124.140145 
+L 127.19952 20.037891 
+L 18.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,17 +41,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m4289229a36" d="M 0 0 
+       <path id="m95c7b636bd" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m4289229a36" x="21.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="18.14875" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- 0 -->
-      <g transform="translate(18.924615 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(15.924375 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -82,12 +82,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m4289229a36" x="64.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="61.769058" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- 2 -->
-      <g transform="translate(62.544923 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(59.544683 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-15" d="M 200 0 
 Q 231 578 439 1006 
@@ -122,12 +122,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m4289229a36" x="108.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="105.389366" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 4 -->
-      <g transform="translate(106.165231 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(103.164991 136.640145) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -158,17 +158,17 @@ z
     <g id="ytick_1">
      <g id="line2d_4">
       <defs>
-       <path id="m580e7cc064" d="M 0 0 
+       <path id="m6bc4fe4ffb" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m580e7cc064" x="21.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="18.14875" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 1 -->
-      <g transform="translate(10.20024 122.408224) scale(0.08 -0.08)">
+      <g transform="translate(7.2 122.408224) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -189,12 +189,12 @@ z
     <g id="ytick_2">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m580e7cc064" x="21.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="18.14875" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 2 -->
-      <g transform="translate(10.20024 103.480542) scale(0.08 -0.08)">
+      <g transform="translate(7.2 103.480542) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -202,12 +202,12 @@ z
     <g id="ytick_3">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m580e7cc064" x="21.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="18.14875" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 3 -->
-      <g transform="translate(10.20024 84.552859) scale(0.08 -0.08)">
+      <g transform="translate(7.2 84.552859) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -251,12 +251,12 @@ z
     <g id="ytick_4">
      <g id="line2d_7">
       <g>
-       <use xlink:href="#m580e7cc064" x="21.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="18.14875" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 4 -->
-      <g transform="translate(10.20024 65.625177) scale(0.08 -0.08)">
+      <g transform="translate(7.2 65.625177) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -264,12 +264,12 @@ z
     <g id="ytick_5">
      <g id="line2d_8">
       <g>
-       <use xlink:href="#m580e7cc064" x="21.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="18.14875" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 5 -->
-      <g transform="translate(10.20024 46.697494) scale(0.08 -0.08)">
+      <g transform="translate(7.2 46.697494) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-18" d="M 791 1141 
 Q 847 659 1238 475 
@@ -305,12 +305,12 @@ z
     <g id="ytick_6">
      <g id="line2d_9">
       <g>
-       <use xlink:href="#m580e7cc064" x="21.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="18.14875" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 6 -->
-      <g transform="translate(10.20024 27.769811) scale(0.08 -0.08)">
+      <g transform="translate(7.2 27.769811) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-19" d="M 1872 4494 
 Q 2622 4494 2917 4105 
@@ -349,17 +349,17 @@ z
     </g>
    </g>
    <g id="line2d_10">
-    <path d="M 21.14899 119.408224 
-L 42.959144 81.552859 
-L 64.769298 100.480542 
-L 86.579452 43.697494 
-L 108.389606 62.625177 
-L 130.19976 24.769811 
-" clip-path="url(#p6b60c44216)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 18.14875 119.408224 
+L 39.958904 81.552859 
+L 61.769058 100.480542 
+L 83.579212 43.697494 
+L 105.389366 62.625177 
+L 127.19952 24.769811 
+" clip-path="url(#p5c5446697f)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_10">
     <!-- SHOW_GRID.NONE -->
-    <g transform="translate(37.746406 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(34.746166 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-36" d="M 3163 4506 
 L 3163 3866 
@@ -591,76 +591,76 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 21.14899 124.140145 
-L 21.14899 20.037891 
+    <path d="M 18.14875 124.140145 
+L 18.14875 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_4">
-    <path d="M 21.14899 124.140145 
-L 130.19976 124.140145 
+    <path d="M 18.14875 124.140145 
+L 127.19952 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_5">
-    <path d="M 147.14899 124.140145 
-L 256.19976 124.140145 
-L 256.19976 20.037891 
-L 147.14899 20.037891 
+    <path d="M 144.14875 124.140145 
+L 253.19952 124.140145 
+L 253.19952 20.037891 
+L 144.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_3">
     <g id="xtick_4">
      <g id="line2d_11">
-      <path d="M 147.14899 124.140145 
-L 147.14899 20.037891 
-" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 144.14875 124.140145 
+L 144.14875 20.037891 
+" clip-path="url(#pd614482430)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m4289229a36" x="147.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="144.14875" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 0 -->
-      <g transform="translate(144.924615 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(141.924375 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="xtick_5">
      <g id="line2d_13">
-      <path d="M 190.769298 124.140145 
-L 190.769298 20.037891 
-" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 187.769058 124.140145 
+L 187.769058 20.037891 
+" clip-path="url(#pd614482430)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m4289229a36" x="190.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="187.769058" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 2 -->
-      <g transform="translate(188.544923 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(185.544683 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
     </g>
     <g id="xtick_6">
      <g id="line2d_15">
-      <path d="M 234.389606 124.140145 
-L 234.389606 20.037891 
-" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 231.389366 124.140145 
+L 231.389366 20.037891 
+" clip-path="url(#pd614482430)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m4289229a36" x="234.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="231.389366" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_13">
       <!-- 4 -->
-      <g transform="translate(232.165231 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(229.164991 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -670,12 +670,12 @@ L 234.389606 20.037891
     <g id="ytick_7">
      <g id="line2d_17">
       <g>
-       <use xlink:href="#m580e7cc064" x="147.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="144.14875" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- 1 -->
-      <g transform="translate(136.20024 122.408224) scale(0.08 -0.08)">
+      <g transform="translate(133.2 122.408224) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -683,12 +683,12 @@ L 234.389606 20.037891
     <g id="ytick_8">
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m580e7cc064" x="147.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="144.14875" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- 2 -->
-      <g transform="translate(136.20024 103.480542) scale(0.08 -0.08)">
+      <g transform="translate(133.2 103.480542) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -696,12 +696,12 @@ L 234.389606 20.037891
     <g id="ytick_9">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m580e7cc064" x="147.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="144.14875" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 3 -->
-      <g transform="translate(136.20024 84.552859) scale(0.08 -0.08)">
+      <g transform="translate(133.2 84.552859) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -709,12 +709,12 @@ L 234.389606 20.037891
     <g id="ytick_10">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m580e7cc064" x="147.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="144.14875" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 4 -->
-      <g transform="translate(136.20024 65.625177) scale(0.08 -0.08)">
+      <g transform="translate(133.2 65.625177) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -722,12 +722,12 @@ L 234.389606 20.037891
     <g id="ytick_11">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m580e7cc064" x="147.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="144.14875" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- 5 -->
-      <g transform="translate(136.20024 46.697494) scale(0.08 -0.08)">
+      <g transform="translate(133.2 46.697494) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
       </g>
      </g>
@@ -735,29 +735,29 @@ L 234.389606 20.037891
     <g id="ytick_12">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m580e7cc064" x="147.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="144.14875" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
       <!-- 6 -->
-      <g transform="translate(136.20024 27.769811) scale(0.08 -0.08)">
+      <g transform="translate(133.2 27.769811) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-19"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_23">
-    <path d="M 147.14899 119.408224 
-L 168.959144 81.552859 
-L 190.769298 100.480542 
-L 212.579452 43.697494 
-L 234.389606 62.625177 
-L 256.19976 24.769811 
-" clip-path="url(#pc7a306778e)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 144.14875 119.408224 
+L 165.958904 81.552859 
+L 187.769058 100.480542 
+L 209.579212 43.697494 
+L 231.389366 62.625177 
+L 253.19952 24.769811 
+" clip-path="url(#pd614482430)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_20">
     <!-- SHOW_GRID.X -->
-    <g transform="translate(171.873828 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(168.873588 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-3b" d="M 269 4666 
 L 947 4666 
@@ -789,22 +789,22 @@ z
     </g>
    </g>
    <g id="patch_6">
-    <path d="M 147.14899 124.140145 
-L 147.14899 20.037891 
+    <path d="M 144.14875 124.140145 
+L 144.14875 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_7">
-    <path d="M 147.14899 124.140145 
-L 256.19976 124.140145 
+    <path d="M 144.14875 124.140145 
+L 253.19952 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_3">
    <g id="patch_8">
-    <path d="M 273.14899 124.140145 
-L 382.19976 124.140145 
-L 382.19976 20.037891 
-L 273.14899 20.037891 
+    <path d="M 270.14875 124.140145 
+L 379.19952 124.140145 
+L 379.19952 20.037891 
+L 270.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -812,12 +812,12 @@ z
     <g id="xtick_7">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m4289229a36" x="273.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="270.14875" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 0 -->
-      <g transform="translate(270.924615 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(267.924375 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -825,12 +825,12 @@ z
     <g id="xtick_8">
      <g id="line2d_25">
       <g>
-       <use xlink:href="#m4289229a36" x="316.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="313.769058" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 2 -->
-      <g transform="translate(314.544923 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(311.544683 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -838,12 +838,12 @@ z
     <g id="xtick_9">
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m4289229a36" x="360.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="357.389366" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 4 -->
-      <g transform="translate(358.165231 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(355.164991 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -852,125 +852,125 @@ z
    <g id="matplotlib.axis_6">
     <g id="ytick_13">
      <g id="line2d_27">
-      <path d="M 273.14899 119.408224 
-L 382.19976 119.408224 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 270.14875 119.408224 
+L 379.19952 119.408224 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m580e7cc064" x="273.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="270.14875" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 1 -->
-      <g transform="translate(262.20024 122.408224) scale(0.08 -0.08)">
+      <g transform="translate(259.2 122.408224) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_29">
-      <path d="M 273.14899 100.480542 
-L 382.19976 100.480542 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 270.14875 100.480542 
+L 379.19952 100.480542 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m580e7cc064" x="273.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="270.14875" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
       <!-- 2 -->
-      <g transform="translate(262.20024 103.480542) scale(0.08 -0.08)">
+      <g transform="translate(259.2 103.480542) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_31">
-      <path d="M 273.14899 81.552859 
-L 382.19976 81.552859 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 270.14875 81.552859 
+L 379.19952 81.552859 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m580e7cc064" x="273.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="270.14875" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_26">
       <!-- 3 -->
-      <g transform="translate(262.20024 84.552859) scale(0.08 -0.08)">
+      <g transform="translate(259.2 84.552859) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_33">
-      <path d="M 273.14899 62.625177 
-L 382.19976 62.625177 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 270.14875 62.625177 
+L 379.19952 62.625177 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m580e7cc064" x="273.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="270.14875" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_27">
       <!-- 4 -->
-      <g transform="translate(262.20024 65.625177) scale(0.08 -0.08)">
+      <g transform="translate(259.2 65.625177) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_35">
-      <path d="M 273.14899 43.697494 
-L 382.19976 43.697494 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 270.14875 43.697494 
+L 379.19952 43.697494 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m580e7cc064" x="273.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="270.14875" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_28">
       <!-- 5 -->
-      <g transform="translate(262.20024 46.697494) scale(0.08 -0.08)">
+      <g transform="translate(259.2 46.697494) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
       </g>
      </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_37">
-      <path d="M 273.14899 24.769811 
-L 382.19976 24.769811 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 270.14875 24.769811 
+L 379.19952 24.769811 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_38">
       <g>
-       <use xlink:href="#m580e7cc064" x="273.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="270.14875" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_29">
       <!-- 6 -->
-      <g transform="translate(262.20024 27.769811) scale(0.08 -0.08)">
+      <g transform="translate(259.2 27.769811) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-19"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_39">
-    <path d="M 273.14899 119.408224 
-L 294.959144 81.552859 
-L 316.769298 100.480542 
-L 338.579452 43.697494 
-L 360.389606 62.625177 
-L 382.19976 24.769811 
-" clip-path="url(#pb3d71ea9f2)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 270.14875 119.408224 
+L 291.958904 81.552859 
+L 313.769058 100.480542 
+L 335.579212 43.697494 
+L 357.389366 62.625177 
+L 379.19952 24.769811 
+" clip-path="url(#p2408e182cb)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_30">
     <!-- SHOW_GRID.Y -->
-    <g transform="translate(297.873828 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(294.873588 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-3c" d="M 116 4666 
 L 788 4666 
@@ -999,76 +999,76 @@ z
     </g>
    </g>
    <g id="patch_9">
-    <path d="M 273.14899 124.140145 
-L 273.14899 20.037891 
+    <path d="M 270.14875 124.140145 
+L 270.14875 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_10">
-    <path d="M 273.14899 124.140145 
-L 382.19976 124.140145 
+    <path d="M 270.14875 124.140145 
+L 379.19952 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_4">
    <g id="patch_11">
-    <path d="M 399.14899 124.140145 
-L 508.19976 124.140145 
-L 508.19976 20.037891 
-L 399.14899 20.037891 
+    <path d="M 396.14875 124.140145 
+L 505.19952 124.140145 
+L 505.19952 20.037891 
+L 396.14875 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
    <g id="matplotlib.axis_7">
     <g id="xtick_10">
      <g id="line2d_40">
-      <path d="M 399.14899 124.140145 
-L 399.14899 20.037891 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 124.140145 
+L 396.14875 20.037891 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_41">
       <g>
-       <use xlink:href="#m4289229a36" x="399.14899" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="396.14875" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_31">
       <!-- 0 -->
-      <g transform="translate(396.924615 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(393.924375 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="xtick_11">
      <g id="line2d_42">
-      <path d="M 442.769298 124.140145 
-L 442.769298 20.037891 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 439.769058 124.140145 
+L 439.769058 20.037891 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_43">
       <g>
-       <use xlink:href="#m4289229a36" x="442.769298" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="439.769058" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_32">
       <!-- 2 -->
-      <g transform="translate(440.544923 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(437.544683 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
     </g>
     <g id="xtick_12">
      <g id="line2d_44">
-      <path d="M 486.389606 124.140145 
-L 486.389606 20.037891 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 483.389366 124.140145 
+L 483.389366 20.037891 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_45">
       <g>
-       <use xlink:href="#m4289229a36" x="486.389606" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m95c7b636bd" x="483.389366" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_33">
       <!-- 4 -->
-      <g transform="translate(484.165231 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(481.164991 136.640145) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
@@ -1077,125 +1077,125 @@ L 486.389606 20.037891
    <g id="matplotlib.axis_8">
     <g id="ytick_19">
      <g id="line2d_46">
-      <path d="M 399.14899 119.408224 
-L 508.19976 119.408224 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 119.408224 
+L 505.19952 119.408224 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_47">
       <g>
-       <use xlink:href="#m580e7cc064" x="399.14899" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="396.14875" y="119.408224" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_34">
       <!-- 1 -->
-      <g transform="translate(388.20024 122.408224) scale(0.08 -0.08)">
+      <g transform="translate(385.2 122.408224) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_48">
-      <path d="M 399.14899 100.480542 
-L 508.19976 100.480542 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 100.480542 
+L 505.19952 100.480542 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_49">
       <g>
-       <use xlink:href="#m580e7cc064" x="399.14899" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="396.14875" y="100.480542" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_35">
       <!-- 2 -->
-      <g transform="translate(388.20024 103.480542) scale(0.08 -0.08)">
+      <g transform="translate(385.2 103.480542) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_50">
-      <path d="M 399.14899 81.552859 
-L 508.19976 81.552859 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 81.552859 
+L 505.19952 81.552859 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_51">
       <g>
-       <use xlink:href="#m580e7cc064" x="399.14899" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="396.14875" y="81.552859" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_36">
       <!-- 3 -->
-      <g transform="translate(388.20024 84.552859) scale(0.08 -0.08)">
+      <g transform="translate(385.2 84.552859) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_52">
-      <path d="M 399.14899 62.625177 
-L 508.19976 62.625177 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 62.625177 
+L 505.19952 62.625177 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_53">
       <g>
-       <use xlink:href="#m580e7cc064" x="399.14899" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="396.14875" y="62.625177" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_37">
       <!-- 4 -->
-      <g transform="translate(388.20024 65.625177) scale(0.08 -0.08)">
+      <g transform="translate(385.2 65.625177) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
       </g>
      </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_54">
-      <path d="M 399.14899 43.697494 
-L 508.19976 43.697494 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 43.697494 
+L 505.19952 43.697494 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_55">
       <g>
-       <use xlink:href="#m580e7cc064" x="399.14899" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="396.14875" y="43.697494" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_38">
       <!-- 5 -->
-      <g transform="translate(388.20024 46.697494) scale(0.08 -0.08)">
+      <g transform="translate(385.2 46.697494) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
       </g>
      </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_56">
-      <path d="M 399.14899 24.769811 
-L 508.19976 24.769811 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
+      <path d="M 396.14875 24.769811 
+L 505.19952 24.769811 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #9a9a9a; stroke-opacity: 0.8; stroke-width: 0.8; stroke-linecap: square"/>
      </g>
      <g id="line2d_57">
       <g>
-       <use xlink:href="#m580e7cc064" x="399.14899" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m6bc4fe4ffb" x="396.14875" y="24.769811" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_39">
       <!-- 6 -->
-      <g transform="translate(388.20024 27.769811) scale(0.08 -0.08)">
+      <g transform="translate(385.2 27.769811) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-19"/>
       </g>
      </g>
     </g>
    </g>
    <g id="line2d_58">
-    <path d="M 399.14899 119.408224 
-L 420.959144 81.552859 
-L 442.769298 100.480542 
-L 464.579452 43.697494 
-L 486.389606 62.625177 
-L 508.19976 24.769811 
-" clip-path="url(#pc09d51b53a)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
+    <path d="M 396.14875 119.408224 
+L 417.958904 81.552859 
+L 439.769058 100.480542 
+L 461.579212 43.697494 
+L 483.389366 62.625177 
+L 505.19952 24.769811 
+" clip-path="url(#p1a39360d28)" style="fill: none; stroke: #4e79a7; stroke-width: 1.5; stroke-linecap: square"/>
    </g>
    <g id="text_40">
     <!-- SHOW_GRID.BOTH -->
-    <g transform="translate(415.746406 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(412.746166 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-25" d="M 1153 2228 
 L 1153 519 
@@ -1258,19 +1258,19 @@ z
     </g>
    </g>
    <g id="patch_12">
-    <path d="M 399.14899 124.140145 
-L 399.14899 20.037891 
+    <path d="M 396.14875 124.140145 
+L 396.14875 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_13">
-    <path d="M 399.14899 124.140145 
-L 508.19976 124.140145 
+    <path d="M 396.14875 124.140145 
+L 505.19952 124.140145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="text_41">
    <!-- Grid lines darkened for visibility; when show_grid is unset or NONE, the theme's chart_default_show_grid fills in. -->
-   <g transform="translate(7.2 145.10376) scale(0.085 -0.085)">
+   <g transform="translate(17.624018 156.83976) scale(0.085 -0.085)">
     <defs>
      <path id="DejaVuSans-Oblique-2a" d="M 3494 697 
 L 3738 1919 
@@ -2050,17 +2050,17 @@ z
   </g>
  </g>
  <defs>
-  <clipPath id="p6b60c44216">
-   <rect x="21.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  <clipPath id="p5c5446697f">
+   <rect x="18.14875" y="20.037891" width="109.05077" height="104.102254"/>
   </clipPath>
-  <clipPath id="pc7a306778e">
-   <rect x="147.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  <clipPath id="pd614482430">
+   <rect x="144.14875" y="20.037891" width="109.05077" height="104.102254"/>
   </clipPath>
-  <clipPath id="pb3d71ea9f2">
-   <rect x="273.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  <clipPath id="p2408e182cb">
+   <rect x="270.14875" y="20.037891" width="109.05077" height="104.102254"/>
   </clipPath>
-  <clipPath id="pc09d51b53a">
-   <rect x="399.14899" y="20.037891" width="109.05077" height="104.102254"/>
+  <clipPath id="p1a39360d28">
+   <rect x="396.14875" y="20.037891" width="109.05077" height="104.102254"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/scripts/generate_constant_viz.py
+++ b/docs/assets/scripts/generate_constant_viz.py
@@ -459,7 +459,17 @@ def chart_grid(figs, name, height, cols=None, footnote=None):
         ax.title.set_fontfamily("monospace")
         ax.title.set_fontsize(FS_LABEL)
     if footnote:
-        fig.text(0.0, -0.03, footnote, fontsize=FS_NOTE, color=INK, style="italic")
+        # centered so a note wider than the grid cannot push it off-center,
+        # with a fixed 0.22 in gap whatever the figure height
+        fig.text(
+            0.5,
+            -0.22 / height,
+            footnote,
+            ha="center",
+            fontsize=FS_NOTE,
+            color=INK,
+            style="italic",
+        )
     save(fig, name)
 
 

--- a/docs/assets/scripts/generate_constant_viz.py
+++ b/docs/assets/scripts/generate_constant_viz.py
@@ -1,5 +1,8 @@
 """Generates docs/assets/imgs/const-*.svg — one at-a-glance visualization per
-constants class (fonts, lines, hatches, legends, value formats, colorbars).
+constants class. Text-like constants (fonts, lines, hatches, legends, value
+formats, colorbars) are drawn with raw matplotlib; chart-setting constants
+(bar modes, histogram types, orientation, grid, scales, norms, emphasis,
+aspect ratios) render through the chart fronts (ADR 0013).
 
 Run from the repo root: python docs/assets/scripts/generate_constant_viz.py
 """
@@ -547,11 +550,13 @@ def show_grid():
             "plot_grid_alpha": 0.8,
         }
     )
-    figs = [
-        LineChart(data=data, show_grid=value, title=f"SHOW_GRID.{label}")
-        for label, value in members
-    ]
-    config.reset_config()
+    try:
+        figs = [
+            LineChart(data=data, show_grid=value, title=f"SHOW_GRID.{label}")
+            for label, value in members
+        ]
+    finally:
+        config.reset_config()
     chart_grid(
         figs,
         "const-show-grid.svg",

--- a/docs/assets/scripts/generate_constant_viz.py
+++ b/docs/assets/scripts/generate_constant_viz.py
@@ -16,18 +16,29 @@ from matplotlib.colors import to_rgba
 from matplotlib.patches import FancyBboxPatch, Rectangle
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3]))
+from datachart.charts import BarChart, Heatmap, Histogram, LineChart, ScatterChart
+from datachart.config import config
 from datachart.constants import (
+    ASPECT_RATIO,
+    BAR_MODE,
     COLORBAR_LOCATION,
+    EMPHASIS,
     FONT_STYLE,
     FONT_WEIGHT,
     HATCH_STYLE,
+    HISTOGRAM_TYPE,
     LEGEND_ALIGN,
     LINE_DRAW_STYLE,
     LINE_MARKER,
     LINE_STYLE,
+    NORMALIZE,
+    ORIENTATION,
+    SCALE,
+    SHOW_GRID,
     VALUE_FORMAT,
 )
 from datachart.themes import DEFAULT_THEME
+from datachart.utils import Grid
 from datachart.utils._internal.colors import create_color_cycle
 
 IMGS = pathlib.Path(__file__).resolve().parents[1] / "imgs"
@@ -434,6 +445,223 @@ def colorbar_location():
     save(fig, "const-colorbar-location.svg")
 
 
+def chart_grid(figs, name, height, cols=None, footnote=None):
+    """Compose chart-front figures with Grid, restyled to the const-* look.
+
+    Chart-setting constants are rendered through the datachart fronts, so the
+    figures show the package's actual behavior (ADR 0013).
+    """
+    fig = Grid(figs, max_cols=cols or len(figs), figsize=(7, height))
+    for ax in fig.axes:
+        ax.title.set_fontfamily("monospace")
+        ax.title.set_fontsize(FS_LABEL)
+    if footnote:
+        fig.text(0.0, -0.03, footnote, fontsize=FS_NOTE, color=INK, style="italic")
+    save(fig, name)
+
+
+BAR_SERIES = [
+    [{"label": label, "y": y} for label, y in zip("wxyz", ys)]
+    for ys in ([4, 6, 3, 5], [2, 3, 5, 2], [3, 1, 2, 4])
+]
+
+
+def bar_mode():
+    members = [
+        ("GROUP", BAR_MODE.GROUP),
+        ("STACK", BAR_MODE.STACK),
+        ("OVERLAY", BAR_MODE.OVERLAY),
+    ]
+    figs = [
+        BarChart(data=BAR_SERIES, bar_mode=value, title=f"BAR_MODE.{label}")
+        for label, value in members
+    ]
+    chart_grid(figs, "const-bar-mode.svg", 2.2)
+
+
+def histogram_type():
+    members = [
+        ("BAR", HISTOGRAM_TYPE.BAR),
+        ("BAR_STACKED", HISTOGRAM_TYPE.BAR_STACKED),
+        ("STEP", HISTOGRAM_TYPE.STEP),
+        ("STEP_FILLED", HISTOGRAM_TYPE.STEP_FILLED),
+    ]
+    values = np.random.default_rng(42).normal(0, 1, 400)
+    figs = [
+        Histogram(
+            data=[{"x": x} for x in values],
+            # STEP draws only the edge, which the DEFAULT theme paints white
+            style={
+                "plot_hist_type": value,
+                **(
+                    {"plot_hist_edge_color": DARK, "plot_hist_edge_width": 1.2}
+                    if value == HISTOGRAM_TYPE.STEP
+                    else {}
+                ),
+            },
+            title=f"HISTOGRAM_TYPE.{label}",
+        )
+        for label, value in members
+    ]
+    chart_grid(
+        figs,
+        "const-histogram-type.svg",
+        3.8,
+        cols=2,
+        footnote="Each series draws separately, so BAR_STACKED renders like BAR; "
+        "STEP shows the edge only (recolored here from the theme's white).",
+    )
+
+
+def orientation():
+    members = [
+        ("VERTICAL", ORIENTATION.VERTICAL),
+        ("HORIZONTAL", ORIENTATION.HORIZONTAL),
+    ]
+    figs = [
+        BarChart(
+            data=BAR_SERIES[0],
+            orientation=value,
+            title=f"ORIENTATION.{label}",
+        )
+        for label, value in members
+    ]
+    chart_grid(figs, "const-orientation.svg", 2.6)
+
+
+def show_grid():
+    members = [
+        ("NONE", SHOW_GRID.NONE),
+        ("X", SHOW_GRID.X),
+        ("Y", SHOW_GRID.Y),
+        ("BOTH", SHOW_GRID.BOTH),
+    ]
+    data = [{"x": x, "y": y} for x, y in zip(range(6), [1, 3, 2, 5, 4, 6])]
+    # mute the theme's grid opinion so NONE means no grid, and darken the
+    # grid lines so the panels differ at thumbnail size
+    config.update_config(
+        {
+            "chart_default_show_grid": None,
+            "plot_grid_color": "#9A9A9A",
+            "plot_grid_linewidth": 0.8,
+            "plot_grid_alpha": 0.8,
+        }
+    )
+    figs = [
+        LineChart(data=data, show_grid=value, title=f"SHOW_GRID.{label}")
+        for label, value in members
+    ]
+    config.reset_config()
+    chart_grid(
+        figs,
+        "const-show-grid.svg",
+        1.9,
+        footnote="Grid lines darkened for visibility; when show_grid is unset "
+        "or NONE, the theme's chart_default_show_grid fills in.",
+    )
+
+
+def scale():
+    members = [
+        ("LINEAR", SCALE.LINEAR),
+        ("LOG", SCALE.LOG),
+        ("SYMLOG", SCALE.SYMLOG),
+        ("ASINH", SCALE.ASINH),
+    ]
+    data = [{"x": x, "y": 10**x} for x in range(6)]
+    figs = [
+        LineChart(data=data, scaley=value, title=f"SCALE.{label}")
+        for label, value in members
+    ]
+    chart_grid(
+        figs,
+        "const-scale.svg",
+        1.9,
+        footnote="Same growth data on each value axis; "
+        "SYMLOG and ASINH also accept zero and negative values.",
+    )
+
+
+def normalize():
+    members = [
+        ("LINEAR", NORMALIZE.LINEAR),
+        ("LOG", NORMALIZE.LOG),
+        ("SYMLOG", NORMALIZE.SYMLOG),
+        ("ASINH", NORMALIZE.ASINH),
+        ("LOGIT", NORMALIZE.LOGIT),
+    ]
+    # values in (0, 1) with a wide dynamic range, legal for every norm
+    data = np.geomspace(0.001, 0.95, 16).reshape(4, 4).tolist()
+    figs = [
+        Heatmap(
+            data=data,
+            norm=value,
+            show_colorbars=False,
+            title=f"NORMALIZE.{label}",
+        )
+        for label, value in members
+    ]
+    chart_grid(
+        figs,
+        "const-normalize.svg",
+        1.7,
+        footnote="Same cell values under each norm; "
+        "SYMLOG and ASINH also accept zero and negative values.",
+    )
+
+
+def emphasis():
+    members = [
+        ("BACKGROUND", EMPHASIS.BACKGROUND),
+        ("HIGHLIGHT", EMPHASIS.HIGHLIGHT),
+    ]
+    series = [
+        [{"x": x, "y": y + offset} for x, y in zip(range(6), [1, 3, 2, 5, 4, 6])]
+        for offset in (0, 1.5, 3)
+    ]
+    figs = [
+        LineChart(
+            data=series,
+            subtitle=["alpha", "beta", "gamma"],
+            emphasis=[None, value, None],
+            show_legend=True,
+            title=f"EMPHASIS.{label}",
+        )
+        for label, value in members
+    ]
+    chart_grid(
+        figs,
+        "const-emphasis.svg",
+        2.4,
+        footnote='The "beta" series carries the emphasis role; '
+        "BACKGROUND also drops its legend entry.",
+    )
+
+
+def aspect_ratio():
+    members = [
+        ("AUTO", ASPECT_RATIO.AUTO),
+        ("EQUAL", ASPECT_RATIO.EQUAL),
+    ]
+    rng = np.random.default_rng(7)
+    points = rng.uniform(0, 1, size=(40, 2)) * (2, 4)
+    figs = [
+        ScatterChart(
+            data=[{"x": x, "y": y} for x, y in points],
+            aspect_ratio=value,
+            title=f"ASPECT_RATIO.{label}",
+        )
+        for label, value in members
+    ]
+    chart_grid(
+        figs,
+        "const-aspect-ratio.svg",
+        2.6,
+        footnote="The y range is twice the x range; AUTO stretches the data to "
+        "fill the box, EQUAL keeps one unit equal on both axes.",
+    )
+
+
 def main():
     font_style()
     font_weight()
@@ -445,6 +673,14 @@ def main():
     legend_location()
     value_format()
     colorbar_location()
+    bar_mode()
+    histogram_type()
+    orientation()
+    show_grid()
+    scale()
+    normalize()
+    emphasis()
+    aspect_ratio()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Eight constants classes (`BAR_MODE`, `HISTOGRAM_TYPE`, `ORIENTATION`, `SHOW_GRID`, `SCALE`, `NORMALIZE`, `EMPHASIS`, `ASPECT_RATIO`) had no at-a-glance figure in the reference docs. Each now gets a `const-*.svg` rendered through datachart's own chart fronts and composed with `Grid`, so package-specific behavior (emphasis muting, bar slotting) cannot drift from the docs — recorded in ADR 0013. `FIG_FORMAT`, `COLORS`, and `THEME` stay figure-less deliberately (nothing to draw, or already covered by the Colormaps guide / Theme Gallery).

## Changes
- `generate_constant_viz.py`: a `chart_grid` helper (Grid composition restyled to the const-* look) and one generator function per new class; comparison panels share one dataset legal for every member, with footnotes where a member's distinguishing case is not shown
- `datachart/constants.py`: at-a-glance image references for the eight classes; new usage lines for `SHOW_GRID` and `ASPECT_RATIO`; `SHOW_GRID.NONE`'s description now matches the actual behavior (defers to the theme's `chart_default_show_grid` rather than disabling the grid)
- `docs/adr/0013-constant-figures-via-chart-fronts.md`: records the fronts-render-the-figures decision and the shared-dataset convention
- Eight new `docs/assets/imgs/const-*.svg` files; the ten pre-existing const images are untouched

## Test plan
- `python docs/assets/scripts/generate_constant_viz.py` → all 18 SVGs written, no errors; the 8 new figures visually checked at PNG render (panel titles legible, every member visually distinct)
- `python -m unittest discover test` → 88/88 OK
- `python -m black --check` → clean
