### PR TITLE
fix(histogram): move stacking to bar_mode, give STEP visible edge defaults

### DIFF
--- a/datachart/charts/histogram.py
+++ b/datachart/charts/histogram.py
@@ -10,7 +10,15 @@ from ..typings import (
     VLinePlotAttrs,
     HLinePlotAttrs,
 )
-from ..constants import ASPECT_RATIO, EMPHASIS, FIG_SIZE, SHOW_GRID, ORIENTATION, SCALE
+from ..constants import (
+    ASPECT_RATIO,
+    BAR_MODE,
+    EMPHASIS,
+    FIG_SIZE,
+    SHOW_GRID,
+    ORIENTATION,
+    SCALE,
+)
 
 # ================================================
 # Main Chart Definition
@@ -36,6 +44,7 @@ def Histogram(
     show_cumulative: Optional[bool] = None,
     aspect_ratio: Optional[Union[ASPECT_RATIO, str]] = None,
     orientation: Optional[Union[ORIENTATION, str]] = ORIENTATION.VERTICAL,
+    bar_mode: Optional[Union[BAR_MODE, str]] = None,
     num_bins: Optional[int] = None,
     scalex: Optional[Union[SCALE, str]] = None,
     scaley: Optional[Union[SCALE, str]] = None,
@@ -112,6 +121,10 @@ def Histogram(
         aspect_ratio: The aspect ratio of the axes ("auto" or "equal"). See
             `ASPECT_RATIO`.
         orientation: The orientation of the histogram (vertical or horizontal).
+        bar_mode: How multiple histogram series share the axis: "stack"
+            (stacked on shared bins, the default) or "overlay" (each series
+            drawn individually over the others). "group" has no histogram
+            meaning and behaves like "overlay". See `BAR_MODE`.
         num_bins: The number of bins to split the data into.
         scalex: The x-axis scale (e.g., "log", "linear"). Useful for log-distributed data.
         scaley: The y-axis scale (e.g., "log", "linear").
@@ -171,6 +184,7 @@ def Histogram(
         "show_density": show_density,
         "show_cumulative": show_cumulative,
         "orientation": orientation,
+        "bar_mode": bar_mode,
         "num_bins": num_bins,
         "scalex": scalex,
         "scaley": scaley,

--- a/datachart/constants.py
+++ b/datachart/constants.py
@@ -418,7 +418,9 @@ class LEGEND_LOCATION:
 class HISTOGRAM_TYPE:
     """The supported histogram types.
 
-    Passed as the `plot_hist_type` style attribute of histograms.
+    Passed as the `plot_hist_type` style attribute of histograms: how each
+    series is rendered. How multiple series share the axis is the `bar_mode`
+    setting's job — see `BAR_MODE`.
 
     ![HISTOGRAM_TYPE at a glance](../../assets/imgs/const-histogram-type.svg){ width="100%" }
 
@@ -429,14 +431,14 @@ class HISTOGRAM_TYPE:
 
     Attributes:
         BAR (str): The bar histogram style. Equals to `"bar"`.
-        BAR_STACKED (str): The stacked bar histogram style. Equals to `"barstacked"`.
-        STEP (str): The step histogram style. Equals to `"step"`.
+        STEP (str): The step histogram style: an unfilled outline in the
+            series color. Stacked series draw as `STEP_FILLED`, since a stack
+            needs area. Equals to `"step"`.
         STEP_FILLED (str): The filled step histogram style. Equals to `"stepfilled"`.
 
     """
 
     BAR = "bar"
-    BAR_STACKED = "barstacked"
     STEP = "step"
     STEP_FILLED = "stepfilled"
 
@@ -444,8 +446,10 @@ class HISTOGRAM_TYPE:
 class BAR_MODE:
     """The supported bar modes.
 
-    Passed as the `bar_mode` setting of bar charts and
-    [`Panel`][datachart.utils.Panel]: how multiple bar series share the axis.
+    Passed as the `bar_mode` setting of bar charts, histograms, and
+    [`Panel`][datachart.utils.Panel]: how multiple series share the axis.
+    Bar charts and panels default to `GROUP`; histograms default to `STACK`,
+    and treat `GROUP` (which has no histogram meaning) as `OVERLAY`.
 
     ![BAR_MODE at a glance](../../assets/imgs/const-bar-mode.svg){ width="100%" }
 

--- a/datachart/typings.py
+++ b/datachart/typings.py
@@ -48,6 +48,7 @@ from typing import TypedDict, Union, Tuple, List, Optional, Dict
 
 import matplotlib.colors as colors
 from .constants import (
+    BAR_MODE,
     FIG_SIZE,
     FONT_STYLE,
     FONT_WEIGHT,
@@ -895,6 +896,7 @@ class _HistogramChartAttrs(ChartCommonAttrs):
     Attributes:
         charts (Union[HistogramSingleChartAttrs, List[HistogramSingleChartAttrs]]): The histogram chart definitions.
         orientation (Union[ORIENTATION, str, None]): The orientation of the histogram charts.
+        bar_mode (Union[BAR_MODE, str, None]): How multiple histogram series share the axis.
         num_bins (Union[int, None]): The number of bins the data points are split in to create the histogram.
         show_density (Union[bool, None]): Whether or not to plot the density histogram.
         show_cumulative (Union[bool, None]): Whether or not to plot the cumulative histogram.
@@ -904,6 +906,7 @@ class _HistogramChartAttrs(ChartCommonAttrs):
 
     charts: Union[HistogramSingleChartAttrs, List[HistogramSingleChartAttrs]]
     orientation: Union[ORIENTATION, str, None]
+    bar_mode: Union[BAR_MODE, str, None]
     num_bins: Union[int, None]
     show_density: Union[bool, None]
     show_cumulative: Union[bool, None]

--- a/datachart/utils/_internal/layers.py
+++ b/datachart/utils/_internal/layers.py
@@ -57,7 +57,13 @@ from .config_helpers import (
     configure_axis_limits,
 )
 from ..stats import minimum, maximum
-from ...constants import ASPECT_RATIO, EMPHASIS, ORIENTATION, VALUE_FORMAT
+from ...constants import (
+    ASPECT_RATIO,
+    EMPHASIS,
+    HISTOGRAM_TYPE,
+    ORIENTATION,
+    VALUE_FORMAT,
+)
 from ...config import config
 
 DEFAULT_NUM_BINS = 20
@@ -223,6 +229,15 @@ class BarSlot:
 
 
 @dataclass(frozen=True)
+class HistSlot:
+    """A histogram layer's precomputed heights and offset within the panel stack."""
+
+    bins: np.ndarray
+    heights: np.ndarray
+    bottom: np.ndarray
+
+
+@dataclass(frozen=True)
 class DrawContext:
     """Frozen per-layer instructions a Panel hands to a Layer at draw time."""
 
@@ -231,6 +246,7 @@ class DrawContext:
     legend_label: Optional[str] = None
     alpha: Optional[float] = None
     bar_slot: Optional[BarSlot] = None
+    hist_slot: Optional[HistSlot] = None
     bins: Optional[np.ndarray] = None
     hatch: Optional[str] = None
     emphasis: Optional[str] = None
@@ -513,6 +529,11 @@ class HistogramLayer(Layer):
         self.show_density = self.settings.get("show_density")
         self.show_cumulative = self.settings.get("show_cumulative")
         self.num_bins = self.settings.get("num_bins") or DEFAULT_NUM_BINS
+        # step's outline is the series mark: it follows the cycle color and
+        # the theme line width unless the chart style pins them (ADR 0014)
+        self.step_edge_color_auto = "plot_hist_edge_color" not in self.style
+        self.step_edge_width_auto = "plot_hist_edge_width" not in self.style
+        self.step_edge_width = config["plot_line_width"]
 
     def x_values(self) -> Optional[np.ndarray]:
         return get_chart_data("x", self.chart)
@@ -530,6 +551,16 @@ class HistogramLayer(Layer):
             return
 
         hist_style = self._merge_color("color", ctx.color, self.hist_style)
+        if hist_style.get("histtype") == HISTOGRAM_TYPE.STEP:
+            if ctx.hist_slot is not None:
+                # a stack needs area: step stacks as its filled equivalent (ADR 0014)
+                hist_style["histtype"] = HISTOGRAM_TYPE.STEP_FILLED
+            else:
+                if self.step_edge_color_auto:
+                    # dropping the theme edge lets `color` drive the outline
+                    hist_style.pop("edgecolor", None)
+                if self.step_edge_width_auto:
+                    hist_style["linewidth"] = self.step_edge_width
         if ctx.z_order is not None:
             hist_style["zorder"] = ctx.z_order
         if ctx.alpha is not None:
@@ -537,6 +568,21 @@ class HistogramLayer(Layer):
         if ctx.hatch is not None and "hatch" not in hist_style:
             hist_style["hatch"] = ctx.hatch or None
         self._apply_emphasis(hist_style, ctx.emphasis)
+
+        if ctx.hist_slot is not None:
+            # weighted bin centers reproduce the precomputed stack heights
+            # exactly; density/cumulative are already encoded in them
+            slot = ctx.hist_slot
+            ax.hist(
+                (slot.bins[:-1] + slot.bins[1:]) / 2,
+                bins=slot.bins,
+                weights=slot.heights,
+                bottom=slot.bottom,
+                label=self.label(ctx),
+                orientation=self.orientation,
+                **hist_style,
+            )
+            return
 
         bins = ctx.bins if ctx.bins is not None else self.num_bins
         ax.hist(
@@ -1416,6 +1462,34 @@ def group_from_chart(
     )
 
 
+def _hist_stack_slots(hist_layers: List[HistogramLayer], bins: np.ndarray) -> dict:
+    """Per-layer stacked heights and bottoms on shared bin edges.
+
+    Mirrors matplotlib's stacked-hist math: density normalizes the whole
+    stack's area to 1, cumulative accumulates after the density transform.
+    """
+
+    first = hist_layers[0]
+    density = bool(first.show_density)
+    cumulative = bool(first.show_cumulative)
+    counts = [
+        np.histogram(layer.x_values(), bins=bins)[0].astype(float)
+        for layer in hist_layers
+    ]
+    db = np.diff(bins)
+    total = sum(c.sum() for c in counts)
+
+    slots, bottom = {}, np.zeros(len(db))
+    for layer, heights in zip(hist_layers, counts):
+        if density and total > 0:
+            heights = heights / db / total
+        if cumulative:
+            heights = np.cumsum(heights * db) if density else np.cumsum(heights)
+        slots[id(layer)] = HistSlot(bins=bins, heights=heights, bottom=bottom)
+        bottom = bottom + heights
+    return slots
+
+
 # ================================================
 # Axis Assignment (scale clustering)
 # ================================================
@@ -1702,12 +1776,33 @@ class Panel:
         if bar_mode == "overlay" and len(bar_layers) > 1:
             bar_alpha = s.get("bar_overlay_alpha")
 
-        # histogram handling: shared bins per group, panel-wide overlay alpha
-        hist_layers = [l for l in self.layers if isinstance(l, HistogramLayer)]
-        hist_mode = s.get("hist_mode", "stack")
+        # bar_mode drives histograms too: "stack" stacks on shared bins,
+        # "overlay"/"group" draw each series individually (ADR 0014)
+        hist_pairs = [
+            (group, l)
+            for group in self.groups
+            for l in group.layers
+            if isinstance(l, HistogramLayer) and l.x_values() is not None
+        ]
         hist_alpha = None
-        if hist_mode == "overlay" and len(hist_layers) > 1:
+        if bar_mode != "stack" and len(hist_pairs) > 1:
             hist_alpha = s.get("hist_overlay_alpha")
+
+        # stacking a muted background is meaningless: draw individually
+        hist_slots = {}
+        if (
+            bar_mode == "stack"
+            and len(hist_pairs) > 1
+            and all(group.layer_role(l) is None for group, l in hist_pairs)
+        ):
+            stack_bins = s.get("hist_bins_override")
+            if stack_bins is None:
+                # panel-shared edges, pooled across every stacked layer
+                stack_bins = np.histogram(
+                    np.hstack(tuple(l.x_values() for _, l in hist_pairs)),
+                    bins=hist_pairs[0][0].num_bins,
+                )[1]
+            hist_slots = _hist_stack_slots([l for _, l in hist_pairs], stack_bins)
 
         zorder_defaults = s.get("zorder_defaults", {})
 
@@ -1758,22 +1853,7 @@ class Panel:
             if bins is None:
                 bins = group.hist_bins()
 
-            group_hists = [l for l in group.layers if isinstance(l, HistogramLayer)]
-            # stacking a muted background is meaningless: draw individually
-            stack_hists = (
-                hist_mode == "stack"
-                and len(group_hists) > 0
-                and all(group.layer_role(l) is None for l in group_hists)
-            )
-            if stack_hists:
-                self._draw_hist_stack(
-                    target_ax, group, group_hists, cycle, bins, hatch_assignments
-                )
-
             for layer in group.layers:
-                if isinstance(layer, HistogramLayer) and stack_hists:
-                    continue
-
                 z_order = group.z_order
                 if z_order is None:
                     z_order = zorder_defaults.get(layer.kind)
@@ -1796,6 +1876,7 @@ class Panel:
                         else (hist_alpha if isinstance(layer, HistogramLayer) else None)
                     ),
                     bar_slot=bar_slots.get(id(layer)),
+                    hist_slot=hist_slots.get(id(layer)),
                     bins=bins,
                     hatch=(
                         hatch_assignments[layer.chart_hash]
@@ -1811,54 +1892,6 @@ class Panel:
                 layer.draw(target_ax, ctx)
 
         self._finalize(ax, ax_right, bar_layers, horizontal)
-
-    def _draw_hist_stack(
-        self, ax, group, hist_layers, cycle, bins, hatch_assignments=None
-    ) -> None:
-        """Draw a group's histograms as one stacked call — a cross-layer concern."""
-
-        first = hist_layers[0]
-        xall, labels, colors = [], [], []
-        for layer in hist_layers:
-            xall.append(layer.x_values())
-            labels.append(layer.subtitle)
-            # each layer's own resolved color; the cycle fills the gaps
-            colors.append(
-                layer.hist_style.get("color", cycle[layer.chart_hash]["color"])
-            )
-
-        hist_style = dict(first.hist_style)
-        hist_style["color"] = colors if colors.count(None) == 0 else None
-
-        *_, patch_sets = ax.hist(
-            xall,
-            bins=bins if bins is not None else first.num_bins,
-            label=labels,
-            stacked=True,
-            density=first.show_density,
-            cumulative=first.show_cumulative,
-            orientation=first.orientation,
-            **{k: v for k, v in hist_style.items() if k != "color"},
-            color=hist_style["color"],
-        )
-
-        if len(hist_layers) == 1:
-            patch_sets = [patch_sets]
-
-        # the stacked call shares one alpha; restore each layer's own
-        first_alpha = first.hist_style.get("alpha")
-        for layer, patches in zip(hist_layers, patch_sets):
-            alpha = layer.hist_style.get("alpha")
-            if alpha != first_alpha:
-                for patch in patches:
-                    patch.set_alpha(alpha)
-
-        # the stack shares the first layer's style, so its explicit hatch wins
-        if hatch_assignments is not None and "hatch" not in first.hist_style:
-            for layer, patches in zip(hist_layers, patch_sets):
-                hatch = hatch_assignments[layer.chart_hash]
-                for patch in patches:
-                    patch.set_hatch(hatch or None)
 
     def _finalize(self, ax, ax_right, bar_layers, horizontal) -> None:
         """Apply the furniture; x/y keys are literal, `*_right` keys hit the twin."""
@@ -2054,7 +2087,9 @@ def build_chart_panel_settings(
             else settings["aspect_ratio"]
         ),
         "legend_style": get_legend_style(),
-        "bar_mode": settings.get("bar_mode") or "group",
+        # histograms stack by default; bars group (ADR 0014)
+        "bar_mode": settings.get("bar_mode")
+        or ("stack" if chart_type == "histogram" else "group"),
         "tighten_xlim": chart_type == "linechart",
     }
 

--- a/datachart/utils/compose.py
+++ b/datachart/utils/compose.py
@@ -136,8 +136,9 @@ def Panel(
         ymax: Maximum value for the primary value-axis limits.
         ymin_right: Minimum value for the secondary value-axis limits.
         ymax_right: Maximum value for the secondary value-axis limits.
-        bar_mode: Bar chart overlay mode: "group" (side-by-side), "stack"
-            (stacked), or "overlay" (overlapping). Default is taken from config
+        bar_mode: How bar and histogram series share the axis: "group"
+            (side-by-side bars; histograms overlay), "stack" (stacked), or
+            "overlay" (overlapping). Default is taken from config
             (overlay_bar_mode, default "group"). See `BAR_MODE`.
 
     Returns:

--- a/datachart/utils/overlay.py
+++ b/datachart/utils/overlay.py
@@ -168,7 +168,6 @@ def _overlay_impl(
         "bar_ticks": "group",
         "bar_width": config.get("plot_bar_width", 0.8),
         "bar_overlay_alpha": config.get("overlay_bar_alpha", 0.7),
-        "hist_mode": "overlay",
         "hist_overlay_alpha": config.get("overlay_hist_alpha", 0.6),
         "zorder_defaults": {
             "bar": config.get("overlay_default_zorder_bar", 1),
@@ -261,8 +260,8 @@ def OverlayChart(
         ymax: Maximum value for the primary value-axis limits.
         ymin_right: Minimum value for the secondary value-axis limits.
         ymax_right: Maximum value for the secondary value-axis limits.
-        bar_mode: Bar chart overlay mode: "group", "stack", or "overlay". See
-            `BAR_MODE`.
+        bar_mode: How bar and histogram series share the axis: "group",
+            "stack", or "overlay". See `BAR_MODE`.
 
     Returns:
         A matplotlib Figure containing the overlaid charts.

--- a/docs/adr/0014-histogram-stacking-and-step-defaults.md
+++ b/docs/adr/0014-histogram-stacking-and-step-defaults.md
@@ -1,0 +1,42 @@
+---
+status: accepted
+---
+
+# Histogram stacking moves to bar_mode; step edges follow the series
+
+Two `HISTOGRAM_TYPE` members did not do what they said. `BAR_STACKED` never
+stacked: every histogram series draws through its own `ax.hist` call, and
+matplotlib's `"barstacked"` only stacks arrays passed to one call, so the
+member rendered identically to `BAR`. `STEP` was invisible under half the
+themes: a step histogram is drawn as edge only, and the theme edge defaults
+are fill-oriented — white in DEFAULT, width 0 in MATERIAL and MINIMAL.
+
+`HISTOGRAM_TYPE` becomes strictly a per-series *render style* — `BAR`,
+`STEP`, `STEP_FILLED` — and *how series share the axis* stays `bar_mode`'s
+job, now for histograms too. The Histogram front accepts the `bar_mode`
+setting; the `Panel` (owner of every cross-layer concern, ADR 0001)
+accumulates per-bin bottoms across its histogram layers on the panel-shared
+bin edges and hands each layer its offset through the `DrawContext`, exactly
+parallel to bar-chart stack slotting. `BAR_STACKED` is removed, not aliased,
+per the pre-1.0 policy of ADR 0010.
+
+For `STEP`, the edge is the series mark itself, so the layer defaults the
+edge color to the series cycle color — a theme cannot supply this, since a
+fixed theme color would collapse a multi-series step histogram into one
+color — and the edge width to the theme's `plot_line_width` (the step
+outline is a line-like mark, and the existing key gives every theme control
+without new config surface). Explicit per-chart `plot_hist_edge_*` styles
+override both; filled types keep the fill-oriented theme edges unchanged.
+
+## Considered options
+
+- **Keep `BAR_STACKED` as the stacking trigger.** Rejected: a per-series
+  style flag driving a cross-series concern is the incoherence that made it
+  silently broken in the first place.
+- **Remove stacking entirely.** Rejected: stacked histograms are genuinely
+  useful, and the panel already owns the machinery (shared bins, stack
+  bottoms for bars).
+- **Theme keys for step edges** (e.g. `plot_hist_step_edge_color`).
+  Rejected: the color must track the per-series cycle, which themes cannot
+  know; a width-only key would duplicate what `plot_line_width` already
+  expresses.

--- a/docs/assets/imgs/const-histogram-type.svg
+++ b/docs/assets/imgs/const-histogram-type.svg
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="583.431172pt" height="302.881752pt" viewBox="0 0 583.431172 302.881752" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="512.39952pt" height="302.881752pt" viewBox="0 0 512.39952 302.881752" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
     <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
-    <dc:date>2026-08-23T23:46:43.284004</dc:date>
+    <dc:date>2026-08-24T00:10:22.599831</dc:date>
     <dc:format>image/svg+xml</dc:format>
     <dc:creator>
      <cc:Agent>
@@ -22,18 +22,18 @@
  <g id="figure_1">
   <g id="patch_1">
    <path d="M 0 302.881752 
-L 583.431172 302.881752 
-L 583.431172 -0 
+L 512.39952 302.881752 
+L 512.39952 -0 
 L 0 -0 
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="axes_1">
    <g id="patch_2">
-    <path d="M 58.113326 124.140145 
-L 288.715346 124.140145 
-L 288.715346 20.037891 
-L 58.113326 20.037891 
+    <path d="M 22.5975 124.139793 
+L 253.19952 124.139793 
+L 253.19952 20.037891 
+L 22.5975 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -41,17 +41,17 @@ z
     <g id="xtick_1">
      <g id="line2d_1">
       <defs>
-       <path id="m51763d152d" d="M 0 0 
+       <path id="m5b115a7fb5" d="M 0 0 
 L 0 3 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m51763d152d" x="90.270777" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="54.754951" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_1">
       <!-- −2 -->
-      <g transform="translate(85.710152 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(50.194326 136.639793) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-ef" d="M 3547 1894 
 L 3547 1369 
@@ -94,12 +94,12 @@ z
     <g id="xtick_2">
      <g id="line2d_2">
       <g>
-       <use xlink:href="#m51763d152d" x="128.522287" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="93.006461" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_2">
       <!-- −1 -->
-      <g transform="translate(123.961662 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(88.445836 136.639793) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-14" d="M 613 3169 
 L 613 3600 
@@ -121,12 +121,12 @@ z
     <g id="xtick_3">
      <g id="line2d_3">
       <g>
-       <use xlink:href="#m51763d152d" x="166.773797" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="131.257971" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_3">
       <!-- 0 -->
-      <g transform="translate(164.549422 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(129.033596 136.639793) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-13" d="M 1731 4475 
 Q 2600 4475 2988 3759 
@@ -157,12 +157,12 @@ z
     <g id="xtick_4">
      <g id="line2d_4">
       <g>
-       <use xlink:href="#m51763d152d" x="205.025307" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="169.509481" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_4">
       <!-- 1 -->
-      <g transform="translate(202.800932 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(167.285106 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -170,12 +170,12 @@ z
     <g id="xtick_5">
      <g id="line2d_5">
       <g>
-       <use xlink:href="#m51763d152d" x="243.276817" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="207.760991" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_5">
       <!-- 2 -->
-      <g transform="translate(241.052442 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(205.536616 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -183,12 +183,12 @@ z
     <g id="xtick_6">
      <g id="line2d_6">
       <g>
-       <use xlink:href="#m51763d152d" x="281.528327" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="246.012501" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_6">
       <!-- 3 -->
-      <g transform="translate(279.303952 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(243.788126 136.639793) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-16" d="M 1663 -122 
 Q 869 -122 511 314 
@@ -233,41 +233,41 @@ z
    <g id="matplotlib.axis_2">
     <g id="ytick_1">
      <g id="line2d_7">
-      <path d="M 58.113326 124.140145 
-L 288.715346 124.140145 
-" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 22.5975 124.139793 
+L 253.19952 124.139793 
+" clip-path="url(#p8ebb63f4e7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_8">
       <defs>
-       <path id="m8d584bc601" d="M 0 0 
+       <path id="m49cd55eed5" d="M 0 0 
 L -3 0 
 " style="stroke: #000000; stroke-width: 0.8"/>
       </defs>
       <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_7">
       <!-- 0 -->
-      <g transform="translate(47.164576 127.140145) scale(0.08 -0.08)">
+      <g transform="translate(11.64875 127.139793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_2">
      <g id="line2d_9">
-      <path d="M 58.113326 106.43568 
-L 288.715346 106.43568 
-" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 22.5975 106.435388 
+L 253.19952 106.435388 
+" clip-path="url(#p8ebb63f4e7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_10">
       <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="106.435388" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_8">
       <!-- 10 -->
-      <g transform="translate(42.715826 109.43568) scale(0.08 -0.08)">
+      <g transform="translate(7.2 109.435388) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -275,18 +275,18 @@ L 288.715346 106.43568
     </g>
     <g id="ytick_3">
      <g id="line2d_11">
-      <path d="M 58.113326 88.731215 
-L 288.715346 88.731215 
-" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 22.5975 88.730983 
+L 253.19952 88.730983 
+" clip-path="url(#p8ebb63f4e7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_12">
       <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="88.730983" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_9">
       <!-- 20 -->
-      <g transform="translate(42.715826 91.731215) scale(0.08 -0.08)">
+      <g transform="translate(7.2 91.730983) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -294,18 +294,18 @@ L 288.715346 88.731215
     </g>
     <g id="ytick_4">
      <g id="line2d_13">
-      <path d="M 58.113326 71.02675 
-L 288.715346 71.02675 
-" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 22.5975 71.026578 
+L 253.19952 71.026578 
+" clip-path="url(#p8ebb63f4e7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_14">
       <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="71.026578" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_10">
       <!-- 30 -->
-      <g transform="translate(42.715826 74.02675) scale(0.08 -0.08)">
+      <g transform="translate(7.2 74.026578) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -313,18 +313,18 @@ L 288.715346 71.02675
     </g>
     <g id="ytick_5">
      <g id="line2d_15">
-      <path d="M 58.113326 53.322285 
-L 288.715346 53.322285 
-" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 22.5975 53.322172 
+L 253.19952 53.322172 
+" clip-path="url(#p8ebb63f4e7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_16">
       <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="53.322172" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_11">
       <!-- 40 -->
-      <g transform="translate(42.715826 56.322285) scale(0.08 -0.08)">
+      <g transform="translate(7.2 56.322172) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-17" d="M 2116 1584 
 L 2116 3613 
@@ -353,18 +353,18 @@ z
     </g>
     <g id="ytick_6">
      <g id="line2d_17">
-      <path d="M 58.113326 35.61782 
-L 288.715346 35.61782 
-" clip-path="url(#pc63cb2a5b7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 22.5975 35.617767 
+L 253.19952 35.617767 
+" clip-path="url(#p8ebb63f4e7)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_18">
       <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="35.617767" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_12">
       <!-- 50 -->
-      <g transform="translate(42.715826 38.61782) scale(0.08 -0.08)">
+      <g transform="translate(7.2 38.617767) scale(0.08 -0.08)">
        <defs>
         <path id="Helvetica-18" d="M 791 1141 
 Q 847 659 1238 475 
@@ -400,168 +400,168 @@ z
     </g>
    </g>
    <g id="patch_3">
-    <path d="M 68.595236 124.140145 
-L 79.077146 124.140145 
-L 79.077146 120.599252 
-L 68.595236 120.599252 
+    <path d="M 33.07941 124.139793 
+L 43.56132 124.139793 
+L 43.56132 120.598912 
+L 33.07941 120.598912 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_4">
-    <path d="M 79.077146 124.140145 
-L 89.559056 124.140145 
-L 89.559056 115.287912 
-L 79.077146 115.287912 
+    <path d="M 43.56132 124.139793 
+L 54.04323 124.139793 
+L 54.04323 115.287591 
+L 43.56132 115.287591 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_5">
-    <path d="M 89.559056 124.140145 
-L 100.040966 124.140145 
-L 100.040966 115.287912 
-L 89.559056 115.287912 
+    <path d="M 54.04323 124.139793 
+L 64.52514 124.139793 
+L 64.52514 115.287591 
+L 54.04323 115.287591 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_6">
-    <path d="M 100.040966 124.140145 
-L 110.522876 124.140145 
-L 110.522876 106.43568 
-L 100.040966 106.43568 
+    <path d="M 64.52514 124.139793 
+L 75.00705 124.139793 
+L 75.00705 106.435388 
+L 64.52514 106.435388 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_7">
-    <path d="M 110.522876 124.140145 
-L 121.004786 124.140145 
-L 121.004786 88.731215 
-L 110.522876 88.731215 
+    <path d="M 75.00705 124.139793 
+L 85.48896 124.139793 
+L 85.48896 88.730983 
+L 75.00705 88.730983 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_8">
-    <path d="M 121.004786 124.140145 
-L 131.486696 124.140145 
-L 131.486696 74.567643 
-L 121.004786 74.567643 
+    <path d="M 85.48896 124.139793 
+L 95.97087 124.139793 
+L 95.97087 74.567459 
+L 85.48896 74.567459 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_9">
-    <path d="M 131.486696 124.140145 
-L 141.968606 124.140145 
-L 141.968606 63.944964 
-L 131.486696 63.944964 
+    <path d="M 95.97087 124.139793 
+L 106.45278 124.139793 
+L 106.45278 63.944816 
+L 95.97087 63.944816 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_10">
-    <path d="M 141.968606 124.140145 
-L 152.450516 124.140145 
-L 152.450516 63.944964 
-L 141.968606 63.944964 
+    <path d="M 106.45278 124.139793 
+L 116.93469 124.139793 
+L 116.93469 63.944816 
+L 106.45278 63.944816 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_11">
-    <path d="M 152.450516 124.140145 
-L 162.932426 124.140145 
-L 162.932426 40.929159 
-L 152.450516 40.929159 
+    <path d="M 116.93469 124.139793 
+L 127.4166 124.139793 
+L 127.4166 40.929089 
+L 116.93469 40.929089 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_12">
-    <path d="M 162.932426 124.140145 
-L 173.414336 124.140145 
-L 173.414336 51.551838 
-L 162.932426 51.551838 
+    <path d="M 127.4166 124.139793 
+L 137.89851 124.139793 
+L 137.89851 51.551732 
+L 127.4166 51.551732 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_13">
-    <path d="M 173.414336 124.140145 
-L 183.896246 124.140145 
-L 183.896246 24.995141 
-L 173.414336 24.995141 
+    <path d="M 137.89851 124.139793 
+L 148.38042 124.139793 
+L 148.38042 24.995124 
+L 137.89851 24.995124 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_14">
-    <path d="M 183.896246 124.140145 
-L 194.378156 124.140145 
-L 194.378156 67.485857 
-L 183.896246 67.485857 
+    <path d="M 148.38042 124.139793 
+L 158.86233 124.139793 
+L 158.86233 67.485697 
+L 148.38042 67.485697 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_15">
-    <path d="M 194.378156 124.140145 
-L 204.860066 124.140145 
-L 204.860066 67.485857 
-L 194.378156 67.485857 
+    <path d="M 158.86233 124.139793 
+L 169.34424 124.139793 
+L 169.34424 67.485697 
+L 158.86233 67.485697 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_16">
-    <path d="M 204.860066 124.140145 
-L 215.341976 124.140145 
-L 215.341976 99.353894 
-L 204.860066 99.353894 
+    <path d="M 169.34424 124.139793 
+L 179.82615 124.139793 
+L 179.82615 99.353626 
+L 169.34424 99.353626 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_17">
-    <path d="M 215.341976 124.140145 
-L 225.823886 124.140145 
-L 225.823886 95.813001 
-L 215.341976 95.813001 
+    <path d="M 179.82615 124.139793 
+L 190.30806 124.139793 
+L 190.30806 95.812745 
+L 179.82615 95.812745 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_18">
-    <path d="M 225.823886 124.140145 
-L 236.305796 124.140145 
-L 236.305796 102.894787 
-L 225.823886 102.894787 
+    <path d="M 190.30806 124.139793 
+L 200.78997 124.139793 
+L 200.78997 102.894507 
+L 190.30806 102.894507 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_19">
-    <path d="M 236.305796 124.140145 
-L 246.787706 124.140145 
-L 246.787706 117.058359 
-L 236.305796 117.058359 
+    <path d="M 200.78997 124.139793 
+L 211.27188 124.139793 
+L 211.27188 117.058031 
+L 200.78997 117.058031 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_20">
-    <path d="M 246.787706 124.140145 
-L 257.269616 124.140145 
-L 257.269616 115.287912 
-L 246.787706 115.287912 
+    <path d="M 211.27188 124.139793 
+L 221.75379 124.139793 
+L 221.75379 115.287591 
+L 211.27188 115.287591 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_21">
-    <path d="M 257.269616 124.140145 
-L 267.751526 124.140145 
-L 267.751526 122.369698 
-L 257.269616 122.369698 
+    <path d="M 221.75379 124.139793 
+L 232.2357 124.139793 
+L 232.2357 122.369353 
+L 221.75379 122.369353 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="patch_22">
-    <path d="M 267.751526 124.140145 
-L 278.233436 124.140145 
-L 278.233436 120.599252 
-L 267.751526 120.599252 
+    <path d="M 232.2357 124.139793 
+L 242.71761 124.139793 
+L 242.71761 120.598912 
+L 232.2357 120.598912 
 z
-" clip-path="url(#pc63cb2a5b7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+" clip-path="url(#p8ebb63f4e7)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
    </g>
    <g id="text_13">
     <!-- HISTOGRAM_TYPE.BAR -->
-    <g transform="translate(124.649805 14.037891) scale(0.09 -0.09)">
+    <g transform="translate(89.133979 14.037891) scale(0.09 -0.09)">
      <defs>
       <path id="DejaVuSansMono-2b" d="M 428 4666 
 L 1063 4666 
@@ -857,22 +857,22 @@ z
     </g>
    </g>
    <g id="patch_23">
-    <path d="M 58.113326 124.140145 
-L 58.113326 20.037891 
+    <path d="M 22.5975 124.139793 
+L 22.5975 20.037891 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
    <g id="patch_24">
-    <path d="M 58.113326 124.140145 
-L 288.715346 124.140145 
+    <path d="M 22.5975 124.139793 
+L 253.19952 124.139793 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
   <g id="axes_2">
    <g id="patch_25">
-    <path d="M 310.113326 124.140145 
-L 540.715346 124.140145 
-L 540.715346 20.037891 
-L 310.113326 20.037891 
+    <path d="M 274.5975 124.139793 
+L 505.19952 124.139793 
+L 505.19952 20.037891 
+L 274.5975 20.037891 
 z
 " style="fill: #ffffff"/>
    </g>
@@ -880,12 +880,12 @@ z
     <g id="xtick_7">
      <g id="line2d_19">
       <g>
-       <use xlink:href="#m51763d152d" x="342.270777" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="306.754951" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_14">
       <!-- −2 -->
-      <g transform="translate(337.710152 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(302.194326 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
       </g>
@@ -894,12 +894,12 @@ z
     <g id="xtick_8">
      <g id="line2d_20">
       <g>
-       <use xlink:href="#m51763d152d" x="380.522287" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="345.006461" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_15">
       <!-- −1 -->
-      <g transform="translate(375.961662 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(340.445836 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-ef"/>
        <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
       </g>
@@ -908,12 +908,12 @@ z
     <g id="xtick_9">
      <g id="line2d_21">
       <g>
-       <use xlink:href="#m51763d152d" x="418.773797" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="383.257971" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_16">
       <!-- 0 -->
-      <g transform="translate(416.549422 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(381.033596 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
@@ -921,12 +921,12 @@ z
     <g id="xtick_10">
      <g id="line2d_22">
       <g>
-       <use xlink:href="#m51763d152d" x="457.025307" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="421.509481" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_17">
       <!-- 1 -->
-      <g transform="translate(454.800932 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(419.285106 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
       </g>
      </g>
@@ -934,12 +934,12 @@ z
     <g id="xtick_11">
      <g id="line2d_23">
       <g>
-       <use xlink:href="#m51763d152d" x="495.276817" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="459.760991" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_18">
       <!-- 2 -->
-      <g transform="translate(493.052442 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(457.536616 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
       </g>
      </g>
@@ -947,12 +947,12 @@ z
     <g id="xtick_12">
      <g id="line2d_24">
       <g>
-       <use xlink:href="#m51763d152d" x="533.528327" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m5b115a7fb5" x="498.012501" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_19">
       <!-- 3 -->
-      <g transform="translate(531.303952 136.640145) scale(0.08 -0.08)">
+      <g transform="translate(495.788126 136.639793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
       </g>
      </g>
@@ -961,36 +961,36 @@ z
    <g id="matplotlib.axis_4">
     <g id="ytick_7">
      <g id="line2d_25">
-      <path d="M 310.113326 124.140145 
-L 540.715346 124.140145 
-" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 274.5975 124.139793 
+L 505.19952 124.139793 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_26">
       <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="124.140145" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="124.139793" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_20">
       <!-- 0 -->
-      <g transform="translate(299.164576 127.140145) scale(0.08 -0.08)">
+      <g transform="translate(263.64875 127.139793) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-13"/>
       </g>
      </g>
     </g>
     <g id="ytick_8">
      <g id="line2d_27">
-      <path d="M 310.113326 106.43568 
-L 540.715346 106.43568 
-" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 274.5975 106.435388 
+L 505.19952 106.435388 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_28">
       <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="106.43568" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="106.435388" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_21">
       <!-- 10 -->
-      <g transform="translate(294.715826 109.43568) scale(0.08 -0.08)">
+      <g transform="translate(259.2 109.435388) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-14"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -998,18 +998,18 @@ L 540.715346 106.43568
     </g>
     <g id="ytick_9">
      <g id="line2d_29">
-      <path d="M 310.113326 88.731215 
-L 540.715346 88.731215 
-" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 274.5975 88.730983 
+L 505.19952 88.730983 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_30">
       <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="88.731215" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="88.730983" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_22">
       <!-- 20 -->
-      <g transform="translate(294.715826 91.731215) scale(0.08 -0.08)">
+      <g transform="translate(259.2 91.730983) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-15"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1017,18 +1017,18 @@ L 540.715346 88.731215
     </g>
     <g id="ytick_10">
      <g id="line2d_31">
-      <path d="M 310.113326 71.02675 
-L 540.715346 71.02675 
-" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 274.5975 71.026578 
+L 505.19952 71.026578 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_32">
       <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="71.02675" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="71.026578" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_23">
       <!-- 30 -->
-      <g transform="translate(294.715826 74.02675) scale(0.08 -0.08)">
+      <g transform="translate(259.2 74.026578) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-16"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1036,18 +1036,18 @@ L 540.715346 71.02675
     </g>
     <g id="ytick_11">
      <g id="line2d_33">
-      <path d="M 310.113326 53.322285 
-L 540.715346 53.322285 
-" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 274.5975 53.322172 
+L 505.19952 53.322172 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_34">
       <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="53.322285" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="53.322172" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_24">
       <!-- 40 -->
-      <g transform="translate(294.715826 56.322285) scale(0.08 -0.08)">
+      <g transform="translate(259.2 56.322172) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-17"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1055,18 +1055,18 @@ L 540.715346 53.322285
     </g>
     <g id="ytick_12">
      <g id="line2d_35">
-      <path d="M 310.113326 35.61782 
-L 540.715346 35.61782 
-" clip-path="url(#p31ecac502f)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+      <path d="M 274.5975 35.617767 
+L 505.19952 35.617767 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
      </g>
      <g id="line2d_36">
       <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="35.61782" style="stroke: #000000; stroke-width: 0.8"/>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="35.617767" style="stroke: #000000; stroke-width: 0.8"/>
       </g>
      </g>
      <g id="text_25">
       <!-- 50 -->
-      <g transform="translate(294.715826 38.61782) scale(0.08 -0.08)">
+      <g transform="translate(259.2 38.617767) scale(0.08 -0.08)">
        <use xlink:href="#Helvetica-18"/>
        <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
       </g>
@@ -1074,203 +1074,399 @@ L 540.715346 35.61782
     </g>
    </g>
    <g id="patch_26">
-    <path d="M 320.595236 124.140145 
-L 331.077146 124.140145 
-L 331.077146 120.599252 
-L 320.595236 120.599252 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_27">
-    <path d="M 331.077146 124.140145 
-L 341.559056 124.140145 
-L 341.559056 115.287912 
-L 331.077146 115.287912 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_28">
-    <path d="M 341.559056 124.140145 
-L 352.040966 124.140145 
-L 352.040966 115.287912 
-L 341.559056 115.287912 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_29">
-    <path d="M 352.040966 124.140145 
-L 362.522876 124.140145 
-L 362.522876 106.43568 
-L 352.040966 106.43568 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_30">
-    <path d="M 362.522876 124.140145 
-L 373.004786 124.140145 
-L 373.004786 88.731215 
-L 362.522876 88.731215 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_31">
-    <path d="M 373.004786 124.140145 
-L 383.486696 124.140145 
-L 383.486696 74.567643 
-L 373.004786 74.567643 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_32">
-    <path d="M 383.486696 124.140145 
-L 393.968606 124.140145 
-L 393.968606 63.944964 
-L 383.486696 63.944964 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_33">
-    <path d="M 393.968606 124.140145 
-L 404.450516 124.140145 
-L 404.450516 63.944964 
-L 393.968606 63.944964 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_34">
-    <path d="M 404.450516 124.140145 
-L 414.932426 124.140145 
-L 414.932426 40.929159 
-L 404.450516 40.929159 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_35">
-    <path d="M 414.932426 124.140145 
-L 425.414336 124.140145 
-L 425.414336 51.551838 
-L 414.932426 51.551838 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_36">
-    <path d="M 425.414336 124.140145 
-L 435.896246 124.140145 
-L 435.896246 24.995141 
-L 425.414336 24.995141 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_37">
-    <path d="M 435.896246 124.140145 
-L 446.378156 124.140145 
-L 446.378156 67.485857 
-L 435.896246 67.485857 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_38">
-    <path d="M 446.378156 124.140145 
-L 456.860066 124.140145 
-L 456.860066 67.485857 
-L 446.378156 67.485857 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_39">
-    <path d="M 456.860066 124.140145 
-L 467.341976 124.140145 
-L 467.341976 99.353894 
-L 456.860066 99.353894 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_40">
-    <path d="M 467.341976 124.140145 
-L 477.823886 124.140145 
-L 477.823886 95.813001 
-L 467.341976 95.813001 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_41">
-    <path d="M 477.823886 124.140145 
-L 488.305796 124.140145 
-L 488.305796 102.894787 
-L 477.823886 102.894787 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_42">
-    <path d="M 488.305796 124.140145 
-L 498.787706 124.140145 
-L 498.787706 117.058359 
-L 488.305796 117.058359 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_43">
-    <path d="M 498.787706 124.140145 
-L 509.269616 124.140145 
-L 509.269616 115.287912 
-L 498.787706 115.287912 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_44">
-    <path d="M 509.269616 124.140145 
-L 519.751526 124.140145 
-L 519.751526 122.369698 
-L 509.269616 122.369698 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="patch_45">
-    <path d="M 519.751526 124.140145 
-L 530.233436 124.140145 
-L 530.233436 120.599252 
-L 519.751526 120.599252 
-z
-" clip-path="url(#p31ecac502f)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+    <path d="M 285.07941 124.139793 
+L 285.07941 120.598912 
+L 295.56132 120.598912 
+L 295.56132 115.287591 
+L 306.04323 115.287591 
+L 306.04323 115.287591 
+L 316.52514 115.287591 
+L 316.52514 106.435388 
+L 327.00705 106.435388 
+L 327.00705 88.730983 
+L 337.48896 88.730983 
+L 337.48896 74.567459 
+L 347.97087 74.567459 
+L 347.97087 63.944816 
+L 358.45278 63.944816 
+L 358.45278 63.944816 
+L 368.93469 63.944816 
+L 368.93469 40.929089 
+L 379.4166 40.929089 
+L 379.4166 51.551732 
+L 389.89851 51.551732 
+L 389.89851 24.995124 
+L 400.38042 24.995124 
+L 400.38042 67.485697 
+L 410.86233 67.485697 
+L 410.86233 67.485697 
+L 421.34424 67.485697 
+L 421.34424 99.353626 
+L 431.82615 99.353626 
+L 431.82615 95.812745 
+L 442.30806 95.812745 
+L 442.30806 102.894507 
+L 452.78997 102.894507 
+L 452.78997 117.058031 
+L 463.27188 117.058031 
+L 463.27188 115.287591 
+L 473.75379 115.287591 
+L 473.75379 122.369353 
+L 484.2357 122.369353 
+L 484.2357 120.598912 
+L 494.71761 120.598912 
+L 494.71761 124.139793 
+" clip-path="url(#p78e3c19c9c)" style="fill: none; opacity: 0.9; stroke: #4e79a7; stroke-width: 1.5; stroke-linejoin: miter"/>
    </g>
    <g id="text_26">
-    <!-- HISTOGRAM_TYPE.BAR_STACKED -->
-    <g transform="translate(354.97668 14.037891) scale(0.09 -0.09)">
+    <!-- HISTOGRAM_TYPE.STEP -->
+    <g transform="translate(338.424838 14.037891) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSansMono-2b"/>
+     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-36" transform="translate(903.046875 0)"/>
+     <use xlink:href="#DejaVuSansMono-37" transform="translate(963.25 0)"/>
+     <use xlink:href="#DejaVuSansMono-28" transform="translate(1023.453125 0)"/>
+     <use xlink:href="#DejaVuSansMono-33" transform="translate(1083.65625 0)"/>
+    </g>
+   </g>
+   <g id="patch_27">
+    <path d="M 274.5975 124.139793 
+L 274.5975 20.037891 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_28">
+    <path d="M 274.5975 124.139793 
+L 505.19952 124.139793 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="axes_3">
+   <g id="patch_29">
+    <path d="M 22.5975 260.940145 
+L 253.19952 260.940145 
+L 253.19952 156.838242 
+L 22.5975 156.838242 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_5">
+    <g id="xtick_13">
+     <g id="line2d_37">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="54.754951" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_27">
+      <!-- −2 -->
+      <g transform="translate(50.194326 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_14">
+     <g id="line2d_38">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="93.006461" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_28">
+      <!-- −1 -->
+      <g transform="translate(88.445836 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_15">
+     <g id="line2d_39">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="131.257971" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_29">
+      <!-- 0 -->
+      <g transform="translate(129.033596 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_16">
+     <g id="line2d_40">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="169.509481" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_30">
+      <!-- 1 -->
+      <g transform="translate(167.285106 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_17">
+     <g id="line2d_41">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="207.760991" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_31">
+      <!-- 2 -->
+      <g transform="translate(205.536616 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_18">
+     <g id="line2d_42">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="246.012501" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_32">
+      <!-- 3 -->
+      <g transform="translate(243.788126 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_6">
+    <g id="ytick_13">
+     <g id="line2d_43">
+      <path d="M 22.5975 260.940145 
+L 253.19952 260.940145 
+" clip-path="url(#p40f877edb4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_44">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_33">
+      <!-- 0 -->
+      <g transform="translate(11.64875 263.940145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_14">
+     <g id="line2d_45">
+      <path d="M 22.5975 243.23574 
+L 253.19952 243.23574 
+" clip-path="url(#p40f877edb4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_46">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="243.23574" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_34">
+      <!-- 10 -->
+      <g transform="translate(7.2 246.23574) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_15">
+     <g id="line2d_47">
+      <path d="M 22.5975 225.531335 
+L 253.19952 225.531335 
+" clip-path="url(#p40f877edb4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_48">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="225.531335" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_35">
+      <!-- 20 -->
+      <g transform="translate(7.2 228.531335) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_16">
+     <g id="line2d_49">
+      <path d="M 22.5975 207.826929 
+L 253.19952 207.826929 
+" clip-path="url(#p40f877edb4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_50">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="207.826929" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_36">
+      <!-- 30 -->
+      <g transform="translate(7.2 210.826929) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_17">
+     <g id="line2d_51">
+      <path d="M 22.5975 190.122524 
+L 253.19952 190.122524 
+" clip-path="url(#p40f877edb4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_52">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="190.122524" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_37">
+      <!-- 40 -->
+      <g transform="translate(7.2 193.122524) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_18">
+     <g id="line2d_53">
+      <path d="M 22.5975 172.418119 
+L 253.19952 172.418119 
+" clip-path="url(#p40f877edb4)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_54">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="22.5975" y="172.418119" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_38">
+      <!-- 50 -->
+      <g transform="translate(7.2 175.418119) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-18"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_30">
+    <path d="M 33.07941 260.940145 
+L 33.07941 257.399264 
+L 43.56132 257.399264 
+L 43.56132 252.087942 
+L 54.04323 252.087942 
+L 54.04323 252.087942 
+L 64.52514 252.087942 
+L 64.52514 243.23574 
+L 75.00705 243.23574 
+L 75.00705 225.531335 
+L 85.48896 225.531335 
+L 85.48896 211.36781 
+L 95.97087 211.36781 
+L 95.97087 200.745167 
+L 106.45278 200.745167 
+L 106.45278 200.745167 
+L 116.93469 200.745167 
+L 116.93469 177.72944 
+L 127.4166 177.72944 
+L 127.4166 188.352084 
+L 137.89851 188.352084 
+L 137.89851 161.795476 
+L 148.38042 161.795476 
+L 148.38042 204.286048 
+L 158.86233 204.286048 
+L 158.86233 204.286048 
+L 169.34424 204.286048 
+L 169.34424 236.153978 
+L 179.82615 236.153978 
+L 179.82615 232.613097 
+L 190.30806 232.613097 
+L 190.30806 239.694859 
+L 200.78997 239.694859 
+L 200.78997 253.858383 
+L 211.27188 253.858383 
+L 211.27188 252.087942 
+L 221.75379 252.087942 
+L 221.75379 259.169704 
+L 232.2357 259.169704 
+L 232.2357 257.399264 
+L 242.71761 257.399264 
+L 242.71761 260.940145 
+L 232.2357 260.940145 
+L 232.2357 260.940145 
+L 221.75379 260.940145 
+L 221.75379 260.940145 
+L 211.27188 260.940145 
+L 211.27188 260.940145 
+L 200.78997 260.940145 
+L 200.78997 260.940145 
+L 190.30806 260.940145 
+L 190.30806 260.940145 
+L 179.82615 260.940145 
+L 179.82615 260.940145 
+L 169.34424 260.940145 
+L 169.34424 260.940145 
+L 158.86233 260.940145 
+L 158.86233 260.940145 
+L 148.38042 260.940145 
+L 148.38042 260.940145 
+L 137.89851 260.940145 
+L 137.89851 260.940145 
+L 127.4166 260.940145 
+L 127.4166 260.940145 
+L 116.93469 260.940145 
+L 116.93469 260.940145 
+L 106.45278 260.940145 
+L 106.45278 260.940145 
+L 95.97087 260.940145 
+L 95.97087 260.940145 
+L 85.48896 260.940145 
+L 85.48896 260.940145 
+L 75.00705 260.940145 
+L 75.00705 260.940145 
+L 64.52514 260.940145 
+L 64.52514 260.940145 
+L 54.04323 260.940145 
+L 54.04323 260.940145 
+L 43.56132 260.940145 
+L 43.56132 260.940145 
+z
+" clip-path="url(#p40f877edb4)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_39">
+    <!-- HISTOGRAM_TYPE.STEP_FILLED -->
+    <g transform="translate(67.460854 150.838242) scale(0.09 -0.09)">
      <defs>
-      <path id="DejaVuSansMono-26" d="M 3353 166 
-Q 3113 38 2859 -26 
-Q 2606 -91 2322 -91 
-Q 1425 -91 929 543 
-Q 434 1178 434 2328 
-Q 434 3472 932 4111 
-Q 1431 4750 2322 4750 
-Q 2606 4750 2859 4686 
-Q 3113 4622 3353 4494 
-L 3353 3847 
-Q 3122 4038 2856 4138 
-Q 2591 4238 2322 4238 
-Q 1706 4238 1400 3763 
-Q 1094 3288 1094 2328 
-Q 1094 1372 1400 897 
-Q 1706 422 2322 422 
-Q 2597 422 2861 522 
-Q 3125 622 3353 813 
-L 3353 166 
+      <path id="DejaVuSansMono-29" d="M 728 4666 
+L 3475 4666 
+L 3475 4134 
+L 1363 4134 
+L 1363 2759 
+L 3278 2759 
+L 3278 2228 
+L 1363 2228 
+L 1363 0 
+L 728 0 
+L 728 4666 
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSansMono-2e" d="M 428 4666 
-L 1063 4666 
-L 1063 2591 
-L 3034 4666 
-L 3775 4666 
-L 1959 2759 
-L 3828 0 
-L 3066 0 
-L 1544 2338 
-L 1063 1825 
-L 1063 0 
-L 428 0 
-L 428 4666 
+      <path id="DejaVuSansMono-2f" d="M 672 4666 
+L 1306 4666 
+L 1306 531 
+L 3559 531 
+L 3559 0 
+L 672 0 
+L 672 4666 
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSansMono-27" d="M 1363 519 
@@ -1308,648 +1504,6 @@ z
      <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
      <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
      <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
-     <use xlink:href="#DejaVuSansMono-25" transform="translate(903.046875 0)"/>
-     <use xlink:href="#DejaVuSansMono-24" transform="translate(963.25 0)"/>
-     <use xlink:href="#DejaVuSansMono-35" transform="translate(1023.453125 0)"/>
-     <use xlink:href="#DejaVuSansMono-42" transform="translate(1083.65625 0)"/>
-     <use xlink:href="#DejaVuSansMono-36" transform="translate(1143.859375 0)"/>
-     <use xlink:href="#DejaVuSansMono-37" transform="translate(1204.0625 0)"/>
-     <use xlink:href="#DejaVuSansMono-24" transform="translate(1264.265625 0)"/>
-     <use xlink:href="#DejaVuSansMono-26" transform="translate(1324.46875 0)"/>
-     <use xlink:href="#DejaVuSansMono-2e" transform="translate(1384.671875 0)"/>
-     <use xlink:href="#DejaVuSansMono-28" transform="translate(1444.875 0)"/>
-     <use xlink:href="#DejaVuSansMono-27" transform="translate(1505.078125 0)"/>
-    </g>
-   </g>
-   <g id="patch_46">
-    <path d="M 310.113326 124.140145 
-L 310.113326 20.037891 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_47">
-    <path d="M 310.113326 124.140145 
-L 540.715346 124.140145 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-  </g>
-  <g id="axes_3">
-   <g id="patch_48">
-    <path d="M 58.113326 260.940145 
-L 288.715346 260.940145 
-L 288.715346 156.837891 
-L 58.113326 156.837891 
-z
-" style="fill: #ffffff"/>
-   </g>
-   <g id="matplotlib.axis_5">
-    <g id="xtick_13">
-     <g id="line2d_37">
-      <g>
-       <use xlink:href="#m51763d152d" x="90.270777" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_27">
-      <!-- −2 -->
-      <g transform="translate(85.710152 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-ef"/>
-       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_14">
-     <g id="line2d_38">
-      <g>
-       <use xlink:href="#m51763d152d" x="128.522287" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_28">
-      <!-- −1 -->
-      <g transform="translate(123.961662 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-ef"/>
-       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_15">
-     <g id="line2d_39">
-      <g>
-       <use xlink:href="#m51763d152d" x="166.773797" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_29">
-      <!-- 0 -->
-      <g transform="translate(164.549422 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-13"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_16">
-     <g id="line2d_40">
-      <g>
-       <use xlink:href="#m51763d152d" x="205.025307" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_30">
-      <!-- 1 -->
-      <g transform="translate(202.800932 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-14"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_17">
-     <g id="line2d_41">
-      <g>
-       <use xlink:href="#m51763d152d" x="243.276817" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_31">
-      <!-- 2 -->
-      <g transform="translate(241.052442 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-15"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_18">
-     <g id="line2d_42">
-      <g>
-       <use xlink:href="#m51763d152d" x="281.528327" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_32">
-      <!-- 3 -->
-      <g transform="translate(279.303952 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-16"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_6">
-    <g id="ytick_13">
-     <g id="line2d_43">
-      <path d="M 58.113326 260.940145 
-L 288.715346 260.940145 
-" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_44">
-      <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_33">
-      <!-- 0 -->
-      <g transform="translate(47.164576 263.940145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-13"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_14">
-     <g id="line2d_45">
-      <path d="M 58.113326 243.23568 
-L 288.715346 243.23568 
-" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_46">
-      <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_34">
-      <!-- 10 -->
-      <g transform="translate(42.715826 246.23568) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-14"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_15">
-     <g id="line2d_47">
-      <path d="M 58.113326 225.531215 
-L 288.715346 225.531215 
-" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_48">
-      <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_35">
-      <!-- 20 -->
-      <g transform="translate(42.715826 228.531215) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-15"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_16">
-     <g id="line2d_49">
-      <path d="M 58.113326 207.82675 
-L 288.715346 207.82675 
-" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_50">
-      <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_36">
-      <!-- 30 -->
-      <g transform="translate(42.715826 210.82675) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-16"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_17">
-     <g id="line2d_51">
-      <path d="M 58.113326 190.122285 
-L 288.715346 190.122285 
-" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_52">
-      <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_37">
-      <!-- 40 -->
-      <g transform="translate(42.715826 193.122285) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-17"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_18">
-     <g id="line2d_53">
-      <path d="M 58.113326 172.41782 
-L 288.715346 172.41782 
-" clip-path="url(#pe788ef890e)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_54">
-      <g>
-       <use xlink:href="#m8d584bc601" x="58.113326" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_38">
-      <!-- 50 -->
-      <g transform="translate(42.715826 175.41782) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-18"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="patch_49">
-    <path d="M 68.595236 260.940145 
-L 68.595236 257.399252 
-L 79.077146 257.399252 
-L 79.077146 252.087912 
-L 89.559056 252.087912 
-L 89.559056 252.087912 
-L 100.040966 252.087912 
-L 100.040966 243.23568 
-L 110.522876 243.23568 
-L 110.522876 225.531215 
-L 121.004786 225.531215 
-L 121.004786 211.367643 
-L 131.486696 211.367643 
-L 131.486696 200.744964 
-L 141.968606 200.744964 
-L 141.968606 200.744964 
-L 152.450516 200.744964 
-L 152.450516 177.729159 
-L 162.932426 177.729159 
-L 162.932426 188.351838 
-L 173.414336 188.351838 
-L 173.414336 161.795141 
-L 183.896246 161.795141 
-L 183.896246 204.285857 
-L 194.378156 204.285857 
-L 194.378156 204.285857 
-L 204.860066 204.285857 
-L 204.860066 236.153894 
-L 215.341976 236.153894 
-L 215.341976 232.613001 
-L 225.823886 232.613001 
-L 225.823886 239.694787 
-L 236.305796 239.694787 
-L 236.305796 253.858359 
-L 246.787706 253.858359 
-L 246.787706 252.087912 
-L 257.269616 252.087912 
-L 257.269616 259.169698 
-L 267.751526 259.169698 
-L 267.751526 257.399252 
-L 278.233436 257.399252 
-L 278.233436 260.940145 
-" clip-path="url(#pe788ef890e)" style="fill: none; opacity: 0.9; stroke: #08306b; stroke-width: 1.2; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_39">
-    <!-- HISTOGRAM_TYPE.STEP -->
-    <g transform="translate(121.940664 150.837891) scale(0.09 -0.09)">
-     <use xlink:href="#DejaVuSansMono-2b"/>
-     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
-     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
-     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
-     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
-     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
-     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
-     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
-     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
-     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
-     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
-     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
-     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
-     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
-     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
-     <use xlink:href="#DejaVuSansMono-36" transform="translate(903.046875 0)"/>
-     <use xlink:href="#DejaVuSansMono-37" transform="translate(963.25 0)"/>
-     <use xlink:href="#DejaVuSansMono-28" transform="translate(1023.453125 0)"/>
-     <use xlink:href="#DejaVuSansMono-33" transform="translate(1083.65625 0)"/>
-    </g>
-   </g>
-   <g id="patch_50">
-    <path d="M 58.113326 260.940145 
-L 58.113326 156.837891 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-   <g id="patch_51">
-    <path d="M 58.113326 260.940145 
-L 288.715346 260.940145 
-" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
-   </g>
-  </g>
-  <g id="axes_4">
-   <g id="patch_52">
-    <path d="M 310.113326 260.940145 
-L 540.715346 260.940145 
-L 540.715346 156.837891 
-L 310.113326 156.837891 
-z
-" style="fill: #ffffff"/>
-   </g>
-   <g id="matplotlib.axis_7">
-    <g id="xtick_19">
-     <g id="line2d_55">
-      <g>
-       <use xlink:href="#m51763d152d" x="342.270777" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_40">
-      <!-- −2 -->
-      <g transform="translate(337.710152 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-ef"/>
-       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_20">
-     <g id="line2d_56">
-      <g>
-       <use xlink:href="#m51763d152d" x="380.522287" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_41">
-      <!-- −1 -->
-      <g transform="translate(375.961662 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-ef"/>
-       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_21">
-     <g id="line2d_57">
-      <g>
-       <use xlink:href="#m51763d152d" x="418.773797" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_42">
-      <!-- 0 -->
-      <g transform="translate(416.549422 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-13"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_22">
-     <g id="line2d_58">
-      <g>
-       <use xlink:href="#m51763d152d" x="457.025307" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_43">
-      <!-- 1 -->
-      <g transform="translate(454.800932 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-14"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_23">
-     <g id="line2d_59">
-      <g>
-       <use xlink:href="#m51763d152d" x="495.276817" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_44">
-      <!-- 2 -->
-      <g transform="translate(493.052442 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-15"/>
-      </g>
-     </g>
-    </g>
-    <g id="xtick_24">
-     <g id="line2d_60">
-      <g>
-       <use xlink:href="#m51763d152d" x="533.528327" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_45">
-      <!-- 3 -->
-      <g transform="translate(531.303952 273.440145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-16"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="matplotlib.axis_8">
-    <g id="ytick_19">
-     <g id="line2d_61">
-      <path d="M 310.113326 260.940145 
-L 540.715346 260.940145 
-" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_62">
-      <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_46">
-      <!-- 0 -->
-      <g transform="translate(299.164576 263.940145) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-13"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_20">
-     <g id="line2d_63">
-      <path d="M 310.113326 243.23568 
-L 540.715346 243.23568 
-" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_64">
-      <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="243.23568" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_47">
-      <!-- 10 -->
-      <g transform="translate(294.715826 246.23568) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-14"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_21">
-     <g id="line2d_65">
-      <path d="M 310.113326 225.531215 
-L 540.715346 225.531215 
-" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_66">
-      <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="225.531215" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_48">
-      <!-- 20 -->
-      <g transform="translate(294.715826 228.531215) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-15"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_22">
-     <g id="line2d_67">
-      <path d="M 310.113326 207.82675 
-L 540.715346 207.82675 
-" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_68">
-      <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="207.82675" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_49">
-      <!-- 30 -->
-      <g transform="translate(294.715826 210.82675) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-16"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_23">
-     <g id="line2d_69">
-      <path d="M 310.113326 190.122285 
-L 540.715346 190.122285 
-" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_70">
-      <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="190.122285" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_50">
-      <!-- 40 -->
-      <g transform="translate(294.715826 193.122285) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-17"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-    <g id="ytick_24">
-     <g id="line2d_71">
-      <path d="M 310.113326 172.41782 
-L 540.715346 172.41782 
-" clip-path="url(#pee49dd4bbf)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
-     </g>
-     <g id="line2d_72">
-      <g>
-       <use xlink:href="#m8d584bc601" x="310.113326" y="172.41782" style="stroke: #000000; stroke-width: 0.8"/>
-      </g>
-     </g>
-     <g id="text_51">
-      <!-- 50 -->
-      <g transform="translate(294.715826 175.41782) scale(0.08 -0.08)">
-       <use xlink:href="#Helvetica-18"/>
-       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
-      </g>
-     </g>
-    </g>
-   </g>
-   <g id="patch_53">
-    <path d="M 320.595236 260.940145 
-L 320.595236 257.399252 
-L 331.077146 257.399252 
-L 331.077146 252.087912 
-L 341.559056 252.087912 
-L 341.559056 252.087912 
-L 352.040966 252.087912 
-L 352.040966 243.23568 
-L 362.522876 243.23568 
-L 362.522876 225.531215 
-L 373.004786 225.531215 
-L 373.004786 211.367643 
-L 383.486696 211.367643 
-L 383.486696 200.744964 
-L 393.968606 200.744964 
-L 393.968606 200.744964 
-L 404.450516 200.744964 
-L 404.450516 177.729159 
-L 414.932426 177.729159 
-L 414.932426 188.351838 
-L 425.414336 188.351838 
-L 425.414336 161.795141 
-L 435.896246 161.795141 
-L 435.896246 204.285857 
-L 446.378156 204.285857 
-L 446.378156 204.285857 
-L 456.860066 204.285857 
-L 456.860066 236.153894 
-L 467.341976 236.153894 
-L 467.341976 232.613001 
-L 477.823886 232.613001 
-L 477.823886 239.694787 
-L 488.305796 239.694787 
-L 488.305796 253.858359 
-L 498.787706 253.858359 
-L 498.787706 252.087912 
-L 509.269616 252.087912 
-L 509.269616 259.169698 
-L 519.751526 259.169698 
-L 519.751526 257.399252 
-L 530.233436 257.399252 
-L 530.233436 260.940145 
-L 519.751526 260.940145 
-L 519.751526 260.940145 
-L 509.269616 260.940145 
-L 509.269616 260.940145 
-L 498.787706 260.940145 
-L 498.787706 260.940145 
-L 488.305796 260.940145 
-L 488.305796 260.940145 
-L 477.823886 260.940145 
-L 477.823886 260.940145 
-L 467.341976 260.940145 
-L 467.341976 260.940145 
-L 456.860066 260.940145 
-L 456.860066 260.940145 
-L 446.378156 260.940145 
-L 446.378156 260.940145 
-L 435.896246 260.940145 
-L 435.896246 260.940145 
-L 425.414336 260.940145 
-L 425.414336 260.940145 
-L 414.932426 260.940145 
-L 414.932426 260.940145 
-L 404.450516 260.940145 
-L 404.450516 260.940145 
-L 393.968606 260.940145 
-L 393.968606 260.940145 
-L 383.486696 260.940145 
-L 383.486696 260.940145 
-L 373.004786 260.940145 
-L 373.004786 260.940145 
-L 362.522876 260.940145 
-L 362.522876 260.940145 
-L 352.040966 260.940145 
-L 352.040966 260.940145 
-L 341.559056 260.940145 
-L 341.559056 260.940145 
-L 331.077146 260.940145 
-L 331.077146 260.940145 
-z
-" clip-path="url(#pee49dd4bbf)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
-   </g>
-   <g id="text_52">
-    <!-- HISTOGRAM_TYPE.STEP_FILLED -->
-    <g transform="translate(354.97668 150.837891) scale(0.09 -0.09)">
-     <defs>
-      <path id="DejaVuSansMono-29" d="M 728 4666 
-L 3475 4666 
-L 3475 4134 
-L 1363 4134 
-L 1363 2759 
-L 3278 2759 
-L 3278 2228 
-L 1363 2228 
-L 1363 0 
-L 728 0 
-L 728 4666 
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSansMono-2f" d="M 672 4666 
-L 1306 4666 
-L 1306 531 
-L 3559 531 
-L 3559 0 
-L 672 0 
-L 672 4666 
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSansMono-2b"/>
-     <use xlink:href="#DejaVuSansMono-2c" transform="translate(60.203125 0)"/>
-     <use xlink:href="#DejaVuSansMono-36" transform="translate(120.40625 0)"/>
-     <use xlink:href="#DejaVuSansMono-37" transform="translate(180.609375 0)"/>
-     <use xlink:href="#DejaVuSansMono-32" transform="translate(240.8125 0)"/>
-     <use xlink:href="#DejaVuSansMono-2a" transform="translate(301.015625 0)"/>
-     <use xlink:href="#DejaVuSansMono-35" transform="translate(361.21875 0)"/>
-     <use xlink:href="#DejaVuSansMono-24" transform="translate(421.421875 0)"/>
-     <use xlink:href="#DejaVuSansMono-30" transform="translate(481.625 0)"/>
-     <use xlink:href="#DejaVuSansMono-42" transform="translate(541.828125 0)"/>
-     <use xlink:href="#DejaVuSansMono-37" transform="translate(602.03125 0)"/>
-     <use xlink:href="#DejaVuSansMono-3c" transform="translate(662.234375 0)"/>
-     <use xlink:href="#DejaVuSansMono-33" transform="translate(722.4375 0)"/>
-     <use xlink:href="#DejaVuSansMono-28" transform="translate(782.640625 0)"/>
-     <use xlink:href="#DejaVuSansMono-11" transform="translate(842.84375 0)"/>
      <use xlink:href="#DejaVuSansMono-36" transform="translate(903.046875 0)"/>
      <use xlink:href="#DejaVuSansMono-37" transform="translate(963.25 0)"/>
      <use xlink:href="#DejaVuSansMono-28" transform="translate(1023.453125 0)"/>
@@ -1963,34 +1517,1207 @@ z
      <use xlink:href="#DejaVuSansMono-27" transform="translate(1505.078125 0)"/>
     </g>
    </g>
-   <g id="patch_54">
-    <path d="M 310.113326 260.940145 
-L 310.113326 156.837891 
+   <g id="patch_31">
+    <path d="M 22.5975 260.940145 
+L 22.5975 156.838242 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
-   <g id="patch_55">
-    <path d="M 310.113326 260.940145 
-L 540.715346 260.940145 
+   <g id="patch_32">
+    <path d="M 22.5975 260.940145 
+L 253.19952 260.940145 
 " style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_53">
-   <!-- Each series draws separately, so BAR_STACKED renders like BAR; STEP shows the edge only (recolored here from the theme's white). -->
-   <g transform="translate(7.2 293.63976) scale(0.085 -0.085)">
+  <g id="axes_4">
+   <g id="patch_33">
+    <path d="M 274.5975 260.940145 
+L 505.19952 260.940145 
+L 505.19952 156.838242 
+L 274.5975 156.838242 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="matplotlib.axis_7">
+    <g id="xtick_19">
+     <g id="line2d_55">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="301.705949" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_40">
+      <!-- −2 -->
+      <g transform="translate(297.145324 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-15" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_20">
+     <g id="line2d_56">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="331.047327" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_41">
+      <!-- −1 -->
+      <g transform="translate(326.486702 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-ef"/>
+       <use xlink:href="#Helvetica-14" transform="translate(58.40625 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_21">
+     <g id="line2d_57">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="360.388705" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_42">
+      <!-- 0 -->
+      <g transform="translate(358.16433 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_22">
+     <g id="line2d_58">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="389.730083" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_43">
+      <!-- 1 -->
+      <g transform="translate(387.505708 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-14"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_23">
+     <g id="line2d_59">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="419.07146" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_44">
+      <!-- 2 -->
+      <g transform="translate(416.847085 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_24">
+     <g id="line2d_60">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="448.412838" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_45">
+      <!-- 3 -->
+      <g transform="translate(446.188463 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-16"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_25">
+     <g id="line2d_61">
+      <g>
+       <use xlink:href="#m5b115a7fb5" x="477.754216" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_46">
+      <!-- 4 -->
+      <g transform="translate(475.529841 273.440145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_8">
+    <g id="ytick_19">
+     <g id="line2d_62">
+      <path d="M 274.5975 260.940145 
+L 505.19952 260.940145 
+" clip-path="url(#pac85666f41)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_63">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="260.940145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_47">
+      <!-- 0 -->
+      <g transform="translate(263.64875 263.940145) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-13"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_20">
+     <g id="line2d_64">
+      <path d="M 274.5975 228.957994 
+L 505.19952 228.957994 
+" clip-path="url(#pac85666f41)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_65">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="228.957994" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_48">
+      <!-- 20 -->
+      <g transform="translate(259.2 231.957994) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-15"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_21">
+     <g id="line2d_66">
+      <path d="M 274.5975 196.975842 
+L 505.19952 196.975842 
+" clip-path="url(#pac85666f41)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_67">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="196.975842" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_49">
+      <!-- 40 -->
+      <g transform="translate(259.2 199.975842) scale(0.08 -0.08)">
+       <use xlink:href="#Helvetica-17"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_22">
+     <g id="line2d_68">
+      <path d="M 274.5975 164.993691 
+L 505.19952 164.993691 
+" clip-path="url(#pac85666f41)" style="fill: none; stroke: #eaeaea; stroke-opacity: 0.5; stroke-width: 0.5; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_69">
+      <g>
+       <use xlink:href="#m49cd55eed5" x="274.5975" y="164.993691" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_50">
+      <!-- 60 -->
+      <g transform="translate(259.2 167.993691) scale(0.08 -0.08)">
+       <defs>
+        <path id="Helvetica-19" d="M 1872 4494 
+Q 2622 4494 2917 4105 
+Q 3213 3716 3213 3303 
+L 2656 3303 
+Q 2606 3569 2497 3719 
+Q 2294 4000 1881 4000 
+Q 1409 4000 1131 3564 
+Q 853 3128 822 2316 
+Q 1016 2600 1309 2741 
+Q 1578 2866 1909 2866 
+Q 2472 2866 2890 2506 
+Q 3309 2147 3309 1434 
+Q 3309 825 2912 354 
+Q 2516 -116 1781 -116 
+Q 1153 -116 697 361 
+Q 241 838 241 1966 
+Q 241 2800 444 3381 
+Q 834 4494 1872 4494 
+z
+M 1831 384 
+Q 2275 384 2495 682 
+Q 2716 981 2716 1388 
+Q 2716 1731 2519 2042 
+Q 2322 2353 1803 2353 
+Q 1441 2353 1167 2112 
+Q 894 1872 894 1388 
+Q 894 963 1142 673 
+Q 1391 384 1831 384 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#Helvetica-19"/>
+       <use xlink:href="#Helvetica-13" transform="translate(55.609375 0)"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="patch_34">
+    <path d="M 285.07941 260.940145 
+L 295.56132 260.940145 
+L 295.56132 256.142822 
+L 285.07941 256.142822 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_35">
+    <path d="M 295.56132 260.940145 
+L 306.04323 260.940145 
+L 306.04323 251.3455 
+L 295.56132 251.3455 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_36">
+    <path d="M 306.04323 260.940145 
+L 316.52514 260.940145 
+L 316.52514 241.750854 
+L 306.04323 241.750854 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_37">
+    <path d="M 316.52514 260.940145 
+L 327.00705 260.940145 
+L 327.00705 217.764241 
+L 316.52514 217.764241 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_38">
+    <path d="M 327.00705 260.940145 
+L 337.48896 260.940145 
+L 337.48896 195.376735 
+L 327.00705 195.376735 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_39">
+    <path d="M 337.48896 260.940145 
+L 347.97087 260.940145 
+L 347.97087 196.975842 
+L 337.48896 196.975842 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_40">
+    <path d="M 347.97087 260.940145 
+L 358.45278 260.940145 
+L 358.45278 163.394583 
+L 347.97087 163.394583 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_41">
+    <path d="M 358.45278 260.940145 
+L 368.93469 260.940145 
+L 368.93469 163.394583 
+L 358.45278 163.394583 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_42">
+    <path d="M 368.93469 260.940145 
+L 379.4166 260.940145 
+L 379.4166 169.791014 
+L 368.93469 169.791014 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_43">
+    <path d="M 379.4166 260.940145 
+L 389.89851 260.940145 
+L 389.89851 196.975842 
+L 379.4166 196.975842 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_44">
+    <path d="M 389.89851 260.940145 
+L 400.38042 260.940145 
+L 400.38042 230.557101 
+L 389.89851 230.557101 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_45">
+    <path d="M 400.38042 260.940145 
+L 410.86233 260.940145 
+L 410.86233 236.953531 
+L 400.38042 236.953531 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_46">
+    <path d="M 410.86233 260.940145 
+L 421.34424 260.940145 
+L 421.34424 244.949069 
+L 410.86233 244.949069 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_47">
+    <path d="M 421.34424 260.940145 
+L 431.82615 260.940145 
+L 431.82615 252.944607 
+L 421.34424 252.944607 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_48">
+    <path d="M 431.82615 260.940145 
+L 442.30806 260.940145 
+L 442.30806 259.341037 
+L 431.82615 259.341037 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_49">
+    <path d="M 442.30806 260.940145 
+L 452.78997 260.940145 
+L 452.78997 257.74193 
+L 442.30806 257.74193 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_50">
+    <path d="M 452.78997 260.940145 
+L 463.27188 260.940145 
+L 463.27188 260.940145 
+L 452.78997 260.940145 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_51">
+    <path d="M 463.27188 260.940145 
+L 473.75379 260.940145 
+L 473.75379 260.940145 
+L 463.27188 260.940145 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_52">
+    <path d="M 473.75379 260.940145 
+L 484.2357 260.940145 
+L 484.2357 260.940145 
+L 473.75379 260.940145 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_53">
+    <path d="M 484.2357 260.940145 
+L 494.71761 260.940145 
+L 494.71761 260.940145 
+L 484.2357 260.940145 
+z
+" clip-path="url(#pac85666f41)" style="fill: #4e79a7; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_54">
+    <path d="M 285.07941 256.142822 
+L 295.56132 256.142822 
+L 295.56132 256.142822 
+L 285.07941 256.142822 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_55">
+    <path d="M 295.56132 251.3455 
+L 306.04323 251.3455 
+L 306.04323 251.3455 
+L 295.56132 251.3455 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_56">
+    <path d="M 306.04323 241.750854 
+L 316.52514 241.750854 
+L 316.52514 241.750854 
+L 306.04323 241.750854 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_57">
+    <path d="M 316.52514 217.764241 
+L 327.00705 217.764241 
+L 327.00705 217.764241 
+L 316.52514 217.764241 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_58">
+    <path d="M 327.00705 195.376735 
+L 337.48896 195.376735 
+L 337.48896 195.376735 
+L 327.00705 195.376735 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_59">
+    <path d="M 337.48896 196.975842 
+L 347.97087 196.975842 
+L 347.97087 196.975842 
+L 337.48896 196.975842 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_60">
+    <path d="M 347.97087 163.394583 
+L 358.45278 163.394583 
+L 358.45278 163.394583 
+L 347.97087 163.394583 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_61">
+    <path d="M 358.45278 163.394583 
+L 368.93469 163.394583 
+L 368.93469 161.795476 
+L 358.45278 161.795476 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_62">
+    <path d="M 368.93469 169.791014 
+L 379.4166 169.791014 
+L 379.4166 163.394583 
+L 368.93469 163.394583 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_63">
+    <path d="M 379.4166 196.975842 
+L 389.89851 196.975842 
+L 389.89851 190.579412 
+L 379.4166 190.579412 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_64">
+    <path d="M 389.89851 230.557101 
+L 400.38042 230.557101 
+L 400.38042 200.174057 
+L 389.89851 200.174057 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_65">
+    <path d="M 400.38042 236.953531 
+L 410.86233 236.953531 
+L 410.86233 208.169595 
+L 400.38042 208.169595 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_66">
+    <path d="M 410.86233 244.949069 
+L 421.34424 244.949069 
+L 421.34424 188.980304 
+L 410.86233 188.980304 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_67">
+    <path d="M 421.34424 252.944607 
+L 431.82615 252.944607 
+L 431.82615 180.984766 
+L 421.34424 180.984766 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_68">
+    <path d="M 431.82615 259.341037 
+L 442.30806 259.341037 
+L 442.30806 192.178519 
+L 431.82615 192.178519 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_69">
+    <path d="M 442.30806 257.74193 
+L 452.78997 257.74193 
+L 452.78997 196.975842 
+L 442.30806 196.975842 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_70">
+    <path d="M 452.78997 260.940145 
+L 463.27188 260.940145 
+L 463.27188 233.755316 
+L 452.78997 233.755316 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_71">
+    <path d="M 463.27188 260.940145 
+L 473.75379 260.940145 
+L 473.75379 235.354424 
+L 463.27188 235.354424 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_72">
+    <path d="M 473.75379 260.940145 
+L 484.2357 260.940145 
+L 484.2357 248.147284 
+L 473.75379 248.147284 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="patch_73">
+    <path d="M 484.2357 260.940145 
+L 494.71761 260.940145 
+L 494.71761 256.142822 
+L 484.2357 256.142822 
+z
+" clip-path="url(#pac85666f41)" style="fill: #f28e2b; opacity: 0.9; stroke: #ffffff; stroke-width: 0.8; stroke-linejoin: miter"/>
+   </g>
+   <g id="text_51">
+    <!-- bar_mode="stack" -->
+    <g transform="translate(346.55226 150.838242) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSansMono-45" d="M 2869 1747 
+Q 2869 2416 2656 2756 
+Q 2444 3097 2028 3097 
+Q 1609 3097 1393 2755 
+Q 1178 2413 1178 1747 
+Q 1178 1084 1393 740 
+Q 1609 397 2028 397 
+Q 2444 397 2656 737 
+Q 2869 1078 2869 1747 
+z
+M 1178 3053 
+Q 1316 3309 1558 3446 
+Q 1800 3584 2119 3584 
+Q 2750 3584 3112 3098 
+Q 3475 2613 3475 1759 
+Q 3475 894 3111 401 
+Q 2747 -91 2113 -91 
+Q 1800 -91 1561 45 
+Q 1322 181 1178 441 
+L 1178 0 
+L 603 0 
+L 603 4863 
+L 1178 4863 
+L 1178 3053 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-44" d="M 2194 1759 
+L 2003 1759 
+Q 1500 1759 1245 1582 
+Q 991 1406 991 1056 
+Q 991 741 1181 566 
+Q 1372 391 1709 391 
+Q 2184 391 2456 720 
+Q 2728 1050 2731 1631 
+L 2731 1759 
+L 2194 1759 
+z
+M 3309 1997 
+L 3309 0 
+L 2731 0 
+L 2731 519 
+Q 2547 206 2267 57 
+Q 1988 -91 1588 -91 
+Q 1053 -91 734 211 
+Q 416 513 416 1019 
+Q 416 1603 808 1906 
+Q 1200 2209 1959 2209 
+L 2731 2209 
+L 2731 2300 
+Q 2728 2719 2518 2908 
+Q 2309 3097 1850 3097 
+Q 1556 3097 1256 3012 
+Q 956 2928 672 2766 
+L 672 3341 
+Q 991 3463 1283 3523 
+Q 1575 3584 1850 3584 
+Q 2284 3584 2592 3456 
+Q 2900 3328 3091 3072 
+Q 3209 2916 3259 2686 
+Q 3309 2456 3309 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-55" d="M 3609 2778 
+Q 3425 2922 3234 2987 
+Q 3044 3053 2816 3053 
+Q 2278 3053 1993 2715 
+Q 1709 2378 1709 1741 
+L 1709 0 
+L 1131 0 
+L 1131 3500 
+L 1709 3500 
+L 1709 2816 
+Q 1853 3188 2151 3386 
+Q 2450 3584 2859 3584 
+Q 3072 3584 3256 3531 
+Q 3441 3478 3609 3366 
+L 3609 2778 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-50" d="M 2113 3144 
+Q 2219 3369 2383 3476 
+Q 2547 3584 2778 3584 
+Q 3200 3584 3373 3257 
+Q 3547 2931 3547 2028 
+L 3547 0 
+L 3022 0 
+L 3022 2003 
+Q 3022 2744 2939 2923 
+Q 2856 3103 2638 3103 
+Q 2388 3103 2295 2911 
+Q 2203 2719 2203 2003 
+L 2203 0 
+L 1678 0 
+L 1678 2003 
+Q 1678 2753 1589 2928 
+Q 1500 3103 1269 3103 
+Q 1041 3103 952 2911 
+Q 863 2719 863 2003 
+L 863 0 
+L 341 0 
+L 341 3500 
+L 863 3500 
+L 863 3200 
+Q 966 3388 1120 3486 
+Q 1275 3584 1472 3584 
+Q 1709 3584 1867 3475 
+Q 2025 3366 2113 3144 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-52" d="M 1925 3097 
+Q 1488 3097 1263 2756 
+Q 1038 2416 1038 1747 
+Q 1038 1081 1263 739 
+Q 1488 397 1925 397 
+Q 2366 397 2591 739 
+Q 2816 1081 2816 1747 
+Q 2816 2416 2591 2756 
+Q 2366 3097 1925 3097 
+z
+M 1925 3584 
+Q 2653 3584 3039 3112 
+Q 3425 2641 3425 1747 
+Q 3425 850 3040 379 
+Q 2656 -91 1925 -91 
+Q 1197 -91 812 379 
+Q 428 850 428 1747 
+Q 428 2641 812 3112 
+Q 1197 3584 1925 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-47" d="M 2681 3053 
+L 2681 4863 
+L 3256 4863 
+L 3256 0 
+L 2681 0 
+L 2681 441 
+Q 2538 181 2298 45 
+Q 2059 -91 1747 -91 
+Q 1113 -91 748 401 
+Q 384 894 384 1759 
+Q 384 2613 750 3098 
+Q 1116 3584 1747 3584 
+Q 2063 3584 2303 3448 
+Q 2544 3313 2681 3053 
+z
+M 991 1747 
+Q 991 1078 1203 737 
+Q 1416 397 1831 397 
+Q 2247 397 2464 740 
+Q 2681 1084 2681 1747 
+Q 2681 2413 2464 2755 
+Q 2247 3097 1831 3097 
+Q 1416 3097 1203 2756 
+Q 991 2416 991 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-48" d="M 3475 1894 
+L 3475 1613 
+L 984 1613 
+L 984 1594 
+Q 984 1022 1282 709 
+Q 1581 397 2125 397 
+Q 2400 397 2700 484 
+Q 3000 572 3341 750 
+L 3341 178 
+Q 3013 44 2708 -23 
+Q 2403 -91 2119 -91 
+Q 1303 -91 843 398 
+Q 384 888 384 1747 
+Q 384 2584 834 3084 
+Q 1284 3584 2034 3584 
+Q 2703 3584 3089 3131 
+Q 3475 2678 3475 1894 
+z
+M 2900 2063 
+Q 2888 2569 2661 2833 
+Q 2434 3097 2009 3097 
+Q 1594 3097 1325 2822 
+Q 1056 2547 1006 2059 
+L 2900 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-20" d="M 275 1638 
+L 3578 1638 
+L 3578 1100 
+L 275 1100 
+L 275 1638 
+z
+M 275 2906 
+L 3578 2906 
+L 3578 2375 
+L 275 2375 
+L 275 2906 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-5" d="M 2797 4666 
+L 2797 2931 
+L 2253 2931 
+L 2253 4666 
+L 2797 4666 
+z
+M 1600 4666 
+L 1600 2931 
+L 1056 2931 
+L 1056 4666 
+L 1600 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-56" d="M 3041 3378 
+L 3041 2816 
+Q 2794 2959 2544 3031 
+Q 2294 3103 2034 3103 
+Q 1644 3103 1451 2976 
+Q 1259 2850 1259 2591 
+Q 1259 2356 1403 2240 
+Q 1547 2125 2119 2016 
+L 2350 1972 
+Q 2778 1891 2998 1647 
+Q 3219 1403 3219 1013 
+Q 3219 494 2850 201 
+Q 2481 -91 1825 -91 
+Q 1566 -91 1281 -36 
+Q 997 19 666 128 
+L 666 722 
+Q 988 556 1281 473 
+Q 1575 391 1838 391 
+Q 2219 391 2428 545 
+Q 2638 700 2638 978 
+Q 2638 1378 1872 1531 
+L 1847 1538 
+L 1631 1581 
+Q 1134 1678 906 1908 
+Q 678 2138 678 2534 
+Q 678 3038 1018 3311 
+Q 1359 3584 1991 3584 
+Q 2272 3584 2531 3532 
+Q 2791 3481 3041 3378 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-57" d="M 1919 4494 
+L 1919 3500 
+L 3225 3500 
+L 3225 3053 
+L 1919 3053 
+L 1919 1153 
+Q 1919 766 2066 612 
+Q 2213 459 2578 459 
+L 3225 459 
+L 3225 0 
+L 2522 0 
+Q 1875 0 1609 259 
+Q 1344 519 1344 1153 
+L 1344 3053 
+L 409 3053 
+L 409 3500 
+L 1344 3500 
+L 1344 4494 
+L 1919 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-46" d="M 3316 178 
+Q 3084 44 2839 -23 
+Q 2594 -91 2338 -91 
+Q 1525 -91 1067 396 
+Q 609 884 609 1747 
+Q 609 2609 1067 3096 
+Q 1525 3584 2338 3584 
+Q 2591 3584 2831 3518 
+Q 3072 3453 3316 3316 
+L 3316 2713 
+Q 3088 2916 2858 3006 
+Q 2628 3097 2338 3097 
+Q 1797 3097 1506 2747 
+Q 1216 2397 1216 1747 
+Q 1216 1100 1508 748 
+Q 1800 397 2338 397 
+Q 2638 397 2875 489 
+Q 3113 581 3316 775 
+L 3316 178 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSansMono-4e" d="M 738 4863 
+L 1331 4863 
+L 1331 2047 
+L 2841 3500 
+L 3541 3500 
+L 2163 2181 
+L 3756 0 
+L 3053 0 
+L 1759 1806 
+L 1331 1403 
+L 1331 0 
+L 738 0 
+L 738 4863 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-45"/>
+     <use xlink:href="#DejaVuSansMono-44" transform="translate(60.203125 0)"/>
+     <use xlink:href="#DejaVuSansMono-55" transform="translate(120.40625 0)"/>
+     <use xlink:href="#DejaVuSansMono-42" transform="translate(180.609375 0)"/>
+     <use xlink:href="#DejaVuSansMono-50" transform="translate(240.8125 0)"/>
+     <use xlink:href="#DejaVuSansMono-52" transform="translate(301.015625 0)"/>
+     <use xlink:href="#DejaVuSansMono-47" transform="translate(361.21875 0)"/>
+     <use xlink:href="#DejaVuSansMono-48" transform="translate(421.421875 0)"/>
+     <use xlink:href="#DejaVuSansMono-20" transform="translate(481.625 0)"/>
+     <use xlink:href="#DejaVuSansMono-5" transform="translate(541.828125 0)"/>
+     <use xlink:href="#DejaVuSansMono-56" transform="translate(602.03125 0)"/>
+     <use xlink:href="#DejaVuSansMono-57" transform="translate(662.234375 0)"/>
+     <use xlink:href="#DejaVuSansMono-44" transform="translate(722.4375 0)"/>
+     <use xlink:href="#DejaVuSansMono-46" transform="translate(782.640625 0)"/>
+     <use xlink:href="#DejaVuSansMono-4e" transform="translate(842.84375 0)"/>
+     <use xlink:href="#DejaVuSansMono-5" transform="translate(903.046875 0)"/>
+    </g>
+   </g>
+   <g id="patch_74">
+    <path d="M 274.5975 260.940145 
+L 274.5975 156.838242 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_75">
+    <path d="M 274.5975 260.940145 
+L 505.19952 260.940145 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+  <g id="text_52">
+   <!-- The type renders one series; how several series share the axis is bar_mode's job. -->
+   <g transform="translate(82.939213 293.63976) scale(0.085 -0.085)">
     <defs>
-     <path id="DejaVuSans-Oblique-28" d="M 1081 4666 
-L 4031 4666 
-L 3928 4134 
+     <path id="DejaVuSans-Oblique-37" d="M 378 4666 
+L 4325 4666 
+L 4225 4134 
+L 2559 4134 
+L 1759 0 
+L 1125 0 
+L 1925 4134 
+L 275 4134 
+L 378 4666 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1617 2771 
+Q 1278 2459 1178 1941 
+L 800 0 
+L 225 0 
+L 1172 4863 
+L 1747 4863 
+L 1375 2950 
+Q 1594 3244 1934 3414 
+Q 2275 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
+Q 3088 2113 3092 2166 
+Q 3097 2219 3097 2272 
+Q 3097 2653 2873 2875 
+Q 2650 3097 2266 3097 
+Q 1838 3097 1509 2826 
+Q 1181 2556 1013 2059 
+L 3078 2063 
+z
+M 3578 1613 
+L 903 1613 
+Q 884 1494 878 1425 
+Q 872 1356 872 1306 
+Q 872 872 1139 634 
+Q 1406 397 1894 397 
+Q 2269 397 2603 481 
+Q 2938 566 3225 728 
+L 3116 159 
+Q 2806 34 2476 -28 
+Q 2147 -91 1806 -91 
+Q 1078 -91 686 257 
+Q 294 606 294 1247 
+Q 294 1794 489 2264 
+Q 684 2734 1063 3103 
+Q 1306 3334 1642 3459 
+Q 1978 3584 2356 3584 
+Q 2950 3584 3301 3228 
+Q 3653 2872 3653 2272 
+Q 3653 2128 3634 1964 
+Q 3616 1800 3578 1613 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
+L 2619 3053 
+L 1472 3053 
+L 1100 1153 
+Q 1081 1047 1072 975 
+Q 1063 903 1063 863 
+Q 1063 663 1183 572 
+Q 1303 481 1569 481 
+L 2150 481 
+L 2053 0 
+L 1503 0 
+Q 991 0 739 200 
+Q 488 400 488 806 
+Q 488 878 497 964 
+Q 506 1050 525 1153 
+L 897 3053 
+L 409 3053 
+L 500 3500 
+L 978 3500 
+L 1172 4494 
+L 1747 4494 
+L 1556 3500 
+L 2706 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5c" d="M 1588 -325 
+Q 1188 -997 936 -1164 
+Q 684 -1331 294 -1331 
+L -159 -1331 
+L -63 -850 
+L 269 -850 
+Q 509 -850 678 -719 
+Q 847 -588 1056 -206 
+L 1234 128 
+L 459 3500 
+L 1069 3500 
+L 1650 819 
+L 3256 3500 
+L 3859 3500 
+L 1588 -325 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
+Q 3175 2616 2975 2859 
+Q 2775 3103 2400 3103 
+Q 2144 3103 1911 2972 
+Q 1678 2841 1497 2591 
+Q 1319 2344 1212 1994 
+Q 1106 1644 1106 1300 
+Q 1106 863 1306 627 
+Q 1506 391 1875 391 
+Q 2147 391 2380 519 
+Q 2613 647 2778 891 
+Q 2956 1147 3065 1494 
+Q 3175 1841 3175 2156 
+z
+M 1394 2969 
+Q 1625 3272 1939 3428 
+Q 2253 3584 2638 3584 
+Q 3175 3584 3472 3232 
+Q 3769 2881 3769 2247 
+Q 3769 1728 3584 1258 
+Q 3400 788 3053 416 
+Q 2822 169 2531 39 
+Q 2241 -91 1919 -91 
+Q 1547 -91 1294 64 
+Q 1041 219 916 525 
+L 556 -1331 
+L -19 -1331 
+L 922 3500 
+L 1497 3500 
+L 1394 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
+Q 2766 3016 2653 3041 
+Q 2541 3066 2413 3066 
+Q 1953 3066 1609 2717 
+Q 1266 2369 1153 1784 
+L 800 0 
+L 225 0 
+L 909 3500 
+L 1484 3500 
+L 1375 2956 
+Q 1603 3259 1920 3421 
+Q 2238 3584 2597 3584 
+Q 2691 3584 2781 3573 
+Q 2872 3563 2963 3538 
+L 2853 2969 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
+L 3156 0 
+L 2578 0 
+L 2988 2091 
+Q 3016 2238 3031 2350 
+Q 3047 2463 3047 2528 
+Q 3047 2791 2881 2937 
+Q 2716 3084 2419 3084 
+Q 1956 3084 1622 2776 
+Q 1288 2469 1184 1941 
+L 800 0 
+L 225 0 
+L 903 3500 
+L 1478 3500 
+L 1363 2950 
+Q 1603 3253 1940 3418 
+Q 2278 3584 2650 3584 
+Q 3113 3584 3367 3334 
+Q 3622 3084 3622 2631 
+Q 3622 2519 3608 2391 
+Q 3594 2263 3566 2113 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
+Q 2444 222 2128 65 
+Q 1813 -91 1428 -91 
+Q 903 -91 598 267 
+Q 294 625 294 1247 
+Q 294 1766 478 2236 
+Q 663 2706 1013 3078 
+Q 1244 3325 1534 3454 
+Q 1825 3584 2144 3584 
+Q 2481 3584 2739 3421 
+Q 2997 3259 3138 2956 
+L 3513 4863 
+L 4091 4863 
+L 3144 0 
+L 2566 0 
+L 2675 525 
+z
+M 891 1350 
+Q 891 897 1095 644 
+Q 1300 391 1663 391 
+Q 1931 391 2161 520 
+Q 2391 650 2566 903 
+Q 2750 1166 2856 1509 
+Q 2963 1853 2963 2188 
+Q 2963 2622 2758 2865 
+Q 2553 3109 2194 3109 
+Q 1922 3109 1687 2981 
+Q 1453 2853 1288 2613 
+Q 1106 2353 998 2009 
+Q 891 1666 891 1350 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
+L 3091 2853 
+Q 2863 2978 2609 3040 
+Q 2356 3103 2088 3103 
+Q 1634 3103 1373 2948 
+Q 1113 2794 1113 2528 
+Q 1113 2219 1719 2053 
+Q 1766 2041 1788 2034 
+L 1972 1978 
+Q 2547 1819 2739 1644 
+Q 2931 1469 2931 1166 
+Q 2931 609 2489 259 
+Q 2047 -91 1331 -91 
+Q 1053 -91 747 -37 
+Q 441 16 72 128 
+L 184 722 
+Q 500 559 806 475 
+Q 1113 391 1394 391 
+Q 1816 391 2080 572 
+Q 2344 753 2344 1031 
+Q 2344 1331 1650 1516 
+L 1591 1531 
+L 1394 1581 
+Q 956 1697 753 1886 
+Q 550 2075 550 2369 
+Q 550 2928 970 3256 
+Q 1391 3584 2113 3584 
+Q 2397 3584 2667 3537 
+Q 2938 3491 3200 3397 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
+Q 1009 -91 651 289 
+Q 294 669 294 1325 
+Q 294 1706 417 2101 
+Q 541 2497 738 2766 
+Q 1047 3184 1428 3384 
+Q 1809 3584 2291 3584 
+Q 2888 3584 3255 3212 
+Q 3622 2841 3622 2241 
+Q 3622 1825 3500 1412 
+Q 3378 1000 3181 728 
+Q 2875 309 2494 109 
+Q 2113 -91 1625 -91 
+z
+M 891 1344 
+Q 891 869 1089 633 
+Q 1288 397 1691 397 
+Q 2269 397 2648 901 
+Q 3028 1406 3028 2181 
+Q 3028 2634 2825 2865 
+Q 2622 3097 2228 3097 
+Q 1903 3097 1650 2945 
+Q 1397 2794 1197 2484 
+Q 1050 2253 970 1956 
+Q 891 1659 891 1344 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
+L 1747 4863 
 L 1606 4134 
-L 1338 2753 
-L 3566 2753 
-L 3463 2222 
-L 1234 2222 
-L 909 531 
-L 3284 531 
-L 3181 0 
-L 172 0 
-L 1081 4666 
+L 1031 4134 
+L 1172 4863 
+z
+M 909 3500 
+L 1484 3500 
+L 800 0 
+L 225 0 
+L 909 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
+L 1222 794 
+L 1113 256 
+L 409 -744 
+L 6 -744 
+L 453 256 
+L 563 794 
+z
+M 1050 3309 
+L 1709 3309 
+L 1556 2516 
+L 897 2516 
+L 1050 3309 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-5a" d="M 544 3500 
+L 1113 3500 
+L 1259 684 
+L 2566 3500 
+L 3231 3500 
+L 3425 684 
+L 4666 3500 
+L 5241 3500 
+L 3641 0 
+L 2969 0 
+L 2797 2900 
+L 1459 0 
+L 781 0 
+L 544 3500 
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-Oblique-59" d="M 459 3500 
+L 1069 3500 
+L 1581 525 
+L 3256 3500 
+L 3866 3500 
+L 1875 0 
+L 1100 0 
+L 459 3500 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-44" d="M 3438 1997 
@@ -2030,253 +2757,6 @@ Q 2678 1069 2791 1631
 L 2816 1759 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-46" d="M 3431 3366 
-L 3316 2797 
-Q 3109 2947 2876 3022 
-Q 2644 3097 2394 3097 
-Q 2119 3097 1870 3000 
-Q 1622 2903 1453 2725 
-Q 1184 2453 1037 2087 
-Q 891 1722 891 1331 
-Q 891 859 1127 628 
-Q 1363 397 1844 397 
-Q 2081 397 2348 469 
-Q 2616 541 2906 684 
-L 2797 116 
-Q 2547 13 2283 -39 
-Q 2019 -91 1741 -91 
-Q 1044 -91 669 257 
-Q 294 606 294 1253 
-Q 294 1797 489 2255 
-Q 684 2713 1069 3078 
-Q 1331 3328 1684 3456 
-Q 2038 3584 2456 3584 
-Q 2700 3584 2940 3529 
-Q 3181 3475 3431 3366 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-4b" d="M 3566 2113 
-L 3156 0 
-L 2578 0 
-L 2988 2091 
-Q 3016 2238 3031 2350 
-Q 3047 2463 3047 2528 
-Q 3047 2791 2881 2937 
-Q 2716 3084 2419 3084 
-Q 1956 3084 1617 2771 
-Q 1278 2459 1178 1941 
-L 800 0 
-L 225 0 
-L 1172 4863 
-L 1747 4863 
-L 1375 2950 
-Q 1594 3244 1934 3414 
-Q 2275 3584 2650 3584 
-Q 3113 3584 3367 3334 
-Q 3622 3084 3622 2631 
-Q 3622 2519 3608 2391 
-Q 3594 2263 3566 2113 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-3" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-56" d="M 3200 3397 
-L 3091 2853 
-Q 2863 2978 2609 3040 
-Q 2356 3103 2088 3103 
-Q 1634 3103 1373 2948 
-Q 1113 2794 1113 2528 
-Q 1113 2219 1719 2053 
-Q 1766 2041 1788 2034 
-L 1972 1978 
-Q 2547 1819 2739 1644 
-Q 2931 1469 2931 1166 
-Q 2931 609 2489 259 
-Q 2047 -91 1331 -91 
-Q 1053 -91 747 -37 
-Q 441 16 72 128 
-L 184 722 
-Q 500 559 806 475 
-Q 1113 391 1394 391 
-Q 1816 391 2080 572 
-Q 2344 753 2344 1031 
-Q 2344 1331 1650 1516 
-L 1591 1531 
-L 1394 1581 
-Q 956 1697 753 1886 
-Q 550 2075 550 2369 
-Q 550 2928 970 3256 
-Q 1391 3584 2113 3584 
-Q 2397 3584 2667 3537 
-Q 2938 3491 3200 3397 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-48" d="M 3078 2063 
-Q 3088 2113 3092 2166 
-Q 3097 2219 3097 2272 
-Q 3097 2653 2873 2875 
-Q 2650 3097 2266 3097 
-Q 1838 3097 1509 2826 
-Q 1181 2556 1013 2059 
-L 3078 2063 
-z
-M 3578 1613 
-L 903 1613 
-Q 884 1494 878 1425 
-Q 872 1356 872 1306 
-Q 872 872 1139 634 
-Q 1406 397 1894 397 
-Q 2269 397 2603 481 
-Q 2938 566 3225 728 
-L 3116 159 
-Q 2806 34 2476 -28 
-Q 2147 -91 1806 -91 
-Q 1078 -91 686 257 
-Q 294 606 294 1247 
-Q 294 1794 489 2264 
-Q 684 2734 1063 3103 
-Q 1306 3334 1642 3459 
-Q 1978 3584 2356 3584 
-Q 2950 3584 3301 3228 
-Q 3653 2872 3653 2272 
-Q 3653 2128 3634 1964 
-Q 3616 1800 3578 1613 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-55" d="M 2853 2969 
-Q 2766 3016 2653 3041 
-Q 2541 3066 2413 3066 
-Q 1953 3066 1609 2717 
-Q 1266 2369 1153 1784 
-L 800 0 
-L 225 0 
-L 909 3500 
-L 1484 3500 
-L 1375 2956 
-Q 1603 3259 1920 3421 
-Q 2238 3584 2597 3584 
-Q 2691 3584 2781 3573 
-Q 2872 3563 2963 3538 
-L 2853 2969 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-4c" d="M 1172 4863 
-L 1747 4863 
-L 1606 4134 
-L 1031 4134 
-L 1172 4863 
-z
-M 909 3500 
-L 1484 3500 
-L 800 0 
-L 225 0 
-L 909 3500 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-47" d="M 2675 525 
-Q 2444 222 2128 65 
-Q 1813 -91 1428 -91 
-Q 903 -91 598 267 
-Q 294 625 294 1247 
-Q 294 1766 478 2236 
-Q 663 2706 1013 3078 
-Q 1244 3325 1534 3454 
-Q 1825 3584 2144 3584 
-Q 2481 3584 2739 3421 
-Q 2997 3259 3138 2956 
-L 3513 4863 
-L 4091 4863 
-L 3144 0 
-L 2566 0 
-L 2675 525 
-z
-M 891 1350 
-Q 891 897 1095 644 
-Q 1300 391 1663 391 
-Q 1931 391 2161 520 
-Q 2391 650 2566 903 
-Q 2750 1166 2856 1509 
-Q 2963 1853 2963 2188 
-Q 2963 2622 2758 2865 
-Q 2553 3109 2194 3109 
-Q 1922 3109 1687 2981 
-Q 1453 2853 1288 2613 
-Q 1106 2353 998 2009 
-Q 891 1666 891 1350 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-5a" d="M 544 3500 
-L 1113 3500 
-L 1259 684 
-L 2566 3500 
-L 3231 3500 
-L 3425 684 
-L 4666 3500 
-L 5241 3500 
-L 3641 0 
-L 2969 0 
-L 2797 2900 
-L 1459 0 
-L 781 0 
-L 544 3500 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-53" d="M 3175 2156 
-Q 3175 2616 2975 2859 
-Q 2775 3103 2400 3103 
-Q 2144 3103 1911 2972 
-Q 1678 2841 1497 2591 
-Q 1319 2344 1212 1994 
-Q 1106 1644 1106 1300 
-Q 1106 863 1306 627 
-Q 1506 391 1875 391 
-Q 2147 391 2380 519 
-Q 2613 647 2778 891 
-Q 2956 1147 3065 1494 
-Q 3175 1841 3175 2156 
-z
-M 1394 2969 
-Q 1625 3272 1939 3428 
-Q 2253 3584 2638 3584 
-Q 3175 3584 3472 3232 
-Q 3769 2881 3769 2247 
-Q 3769 1728 3584 1258 
-Q 3400 788 3053 416 
-Q 2822 169 2531 39 
-Q 2241 -91 1919 -91 
-Q 1547 -91 1294 64 
-Q 1041 219 916 525 
-L 556 -1331 
-L -19 -1331 
-L 922 3500 
-L 1497 3500 
-L 1394 2969 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-57" d="M 2706 3500 
-L 2619 3053 
-L 1472 3053 
-L 1100 1153 
-Q 1081 1047 1072 975 
-Q 1063 903 1063 863 
-Q 1063 663 1183 572 
-Q 1303 481 1569 481 
-L 2150 481 
-L 2053 0 
-L 1503 0 
-Q 991 0 739 200 
-Q 488 400 488 806 
-Q 488 878 497 964 
-Q 506 1050 525 1153 
-L 897 3053 
-L 409 3053 
-L 500 3500 
-L 978 3500 
-L 1172 4494 
-L 1747 4494 
-L 1556 3500 
-L 2706 3500 
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-4f" d="M 1172 4863 
 L 1747 4863 
 L 800 0 
@@ -2284,133 +2764,51 @@ L 225 0
 L 1172 4863 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-5c" d="M 1588 -325 
-Q 1188 -997 936 -1164 
-Q 684 -1331 294 -1331 
-L -159 -1331 
-L -63 -850 
-L 269 -850 
-Q 509 -850 678 -719 
-Q 847 -588 1056 -206 
-L 1234 128 
-L 459 3500 
-L 1069 3500 
-L 1650 819 
-L 3256 3500 
-L 3859 3500 
-L 1588 -325 
+     <path id="DejaVuSans-Oblique-5b" d="M 3841 3500 
+L 2234 1784 
+L 3219 0 
+L 2559 0 
+L 1819 1388 
+L 531 0 
+L -166 0 
+L 1556 1844 
+L 641 3500 
+L 1300 3500 
+L 1972 2234 
+L 3144 3500 
+L 3841 3500 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-f" d="M 575 794 
-L 1234 794 
-L 1131 256 
-L 422 -744 
-L 19 -744 
-L 469 256 
-L 575 794 
+     <path id="DejaVuSans-Oblique-45" d="M 3169 2138 
+Q 3169 2591 2961 2847 
+Q 2753 3103 2388 3103 
+Q 2122 3103 1889 2973 
+Q 1656 2844 1484 2597 
+Q 1303 2338 1198 1995 
+Q 1094 1653 1094 1313 
+Q 1094 881 1298 636 
+Q 1503 391 1863 391 
+Q 2134 391 2365 517 
+Q 2597 644 2772 891 
+Q 2950 1147 3059 1487 
+Q 3169 1828 3169 2138 
 z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-52" d="M 1625 -91 
-Q 1009 -91 651 289 
-Q 294 669 294 1325 
-Q 294 1706 417 2101 
-Q 541 2497 738 2766 
-Q 1047 3184 1428 3384 
-Q 1809 3584 2291 3584 
-Q 2888 3584 3255 3212 
-Q 3622 2841 3622 2241 
-Q 3622 1825 3500 1412 
-Q 3378 1000 3181 728 
-Q 2875 309 2494 109 
-Q 2113 -91 1625 -91 
-z
-M 891 1344 
-Q 891 869 1089 633 
-Q 1288 397 1691 397 
-Q 2269 397 2648 901 
-Q 3028 1406 3028 2181 
-Q 3028 2634 2825 2865 
-Q 2622 3097 2228 3097 
-Q 1903 3097 1650 2945 
-Q 1397 2794 1197 2484 
-Q 1050 2253 970 1956 
-Q 891 1659 891 1344 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-25" d="M 1081 4666 
-L 2694 4666 
-Q 3350 4666 3675 4422 
-Q 4000 4178 4000 3688 
-Q 4000 3238 3720 2911 
-Q 3441 2584 2988 2516 
-Q 3375 2428 3569 2181 
-Q 3763 1934 3763 1522 
-Q 3763 819 3242 409 
-Q 2722 0 1819 0 
-L 172 0 
-L 1081 4666 
-z
-M 1234 2228 
-L 903 519 
-L 1919 519 
-Q 2491 519 2800 781 
-Q 3109 1044 3109 1522 
-Q 3109 1891 2904 2059 
-Q 2700 2228 2247 2228 
-L 1234 2228 
-z
-M 1606 4147 
-L 1331 2741 
-L 2272 2741 
-Q 2775 2741 3058 2959 
-Q 3341 3178 3341 3566 
-Q 3341 3869 3150 4008 
-Q 2959 4147 2541 4147 
-L 1606 4147 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-24" d="M 2356 4666 
-L 3072 4666 
-L 3938 0 
-L 3278 0 
-L 3084 1197 
-L 984 1197 
-L 325 0 
-L -341 0 
-L 2356 4666 
-z
-M 2584 4044 
-L 1275 1722 
-L 2988 1722 
-L 2584 4044 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-35" d="M 1613 4147 
-L 1294 2491 
-L 2106 2491 
-Q 2584 2491 2879 2755 
-Q 3175 3019 3175 3444 
-Q 3175 3784 2976 3965 
-Q 2778 4147 2406 4147 
-L 1613 4147 
-z
-M 2772 2241 
-Q 2972 2194 3105 2009 
-Q 3238 1825 3413 1275 
-L 3809 0 
-L 3144 0 
-L 2778 1197 
-Q 2638 1659 2453 1815 
-Q 2269 1972 1888 1972 
-L 1191 1972 
+M 1381 2969 
+Q 1594 3256 1914 3420 
+Q 2234 3584 2584 3584 
+Q 3122 3584 3439 3221 
+Q 3756 2859 3756 2241 
+Q 3756 1734 3570 1259 
+Q 3384 784 3041 416 
+Q 2816 172 2522 40 
+Q 2228 -91 1906 -91 
+Q 1566 -91 1316 65 
+Q 1066 222 909 531 
 L 806 0 
-L 172 0 
-L 1081 4666 
-L 2503 4666 
-Q 3150 4666 3495 4373 
-Q 3841 4081 3841 3531 
-Q 3841 3044 3547 2687 
-Q 3253 2331 2772 2241 
+L 231 0 
+L 1178 4863 
+L 1753 4863 
+L 1381 2969 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-42" d="M 3263 -1063 
@@ -2418,253 +2816,6 @@ L 3263 -1509
 L -63 -1509 
 L -63 -1063 
 L 3263 -1063 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-36" d="M 3859 4513 
-L 3738 3897 
-Q 3422 4066 3111 4152 
-Q 2800 4238 2509 4238 
-Q 1944 4238 1609 3991 
-Q 1275 3744 1275 3334 
-Q 1275 3109 1398 2989 
-Q 1522 2869 2034 2731 
-L 2413 2638 
-Q 3053 2472 3303 2217 
-Q 3553 1963 3553 1503 
-Q 3553 797 2998 353 
-Q 2444 -91 1538 -91 
-Q 1166 -91 791 -17 
-Q 416 56 38 206 
-L 166 856 
-Q 513 641 861 531 
-Q 1209 422 1556 422 
-Q 2147 422 2503 684 
-Q 2859 947 2859 1369 
-Q 2859 1650 2717 1795 
-Q 2575 1941 2106 2059 
-L 1728 2156 
-Q 1081 2325 845 2545 
-Q 609 2766 609 3163 
-Q 609 3859 1145 4304 
-Q 1681 4750 2541 4750 
-Q 2875 4750 3203 4690 
-Q 3531 4631 3859 4513 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-37" d="M 378 4666 
-L 4325 4666 
-L 4225 4134 
-L 2559 4134 
-L 1759 0 
-L 1125 0 
-L 1925 4134 
-L 275 4134 
-L 378 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-26" d="M 4447 4306 
-L 4319 3641 
-Q 4019 3944 3683 4091 
-Q 3347 4238 2956 4238 
-Q 2422 4238 2017 3981 
-Q 1613 3725 1319 3200 
-Q 1131 2863 1032 2486 
-Q 934 2109 934 1728 
-Q 934 1091 1264 756 
-Q 1594 422 2222 422 
-Q 2656 422 3056 561 
-Q 3456 700 3834 978 
-L 3688 231 
-Q 3316 72 2936 -9 
-Q 2556 -91 2175 -91 
-Q 1278 -91 773 396 
-Q 269 884 269 1753 
-Q 269 2309 461 2846 
-Q 653 3384 1013 3828 
-Q 1394 4300 1883 4525 
-Q 2372 4750 3022 4750 
-Q 3422 4750 3780 4639 
-Q 4138 4528 4447 4306 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-2e" d="M 1081 4666 
-L 1716 4666 
-L 1331 2700 
-L 3781 4666 
-L 4622 4666 
-L 1850 2438 
-L 3878 0 
-L 3109 0 
-L 1247 2272 
-L 806 0 
-L 172 0 
-L 1081 4666 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-27" d="M 1081 4666 
-L 2438 4666 
-Q 3519 4666 4070 4208 
-Q 4622 3750 4622 2847 
-Q 4622 2250 4412 1698 
-Q 4203 1147 3834 769 
-Q 3463 381 2891 190 
-Q 2319 0 1538 0 
-L 172 0 
-L 1081 4666 
-z
-M 1613 4147 
-L 909 519 
-L 1734 519 
-Q 2794 519 3375 1128 
-Q 3956 1738 3956 2847 
-Q 3956 3519 3581 3833 
-Q 3206 4147 2406 4147 
-L 1613 4147 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-51" d="M 3566 2113 
-L 3156 0 
-L 2578 0 
-L 2988 2091 
-Q 3016 2238 3031 2350 
-Q 3047 2463 3047 2528 
-Q 3047 2791 2881 2937 
-Q 2716 3084 2419 3084 
-Q 1956 3084 1622 2776 
-Q 1288 2469 1184 1941 
-L 800 0 
-L 225 0 
-L 903 3500 
-L 1478 3500 
-L 1363 2950 
-Q 1603 3253 1940 3418 
-Q 2278 3584 2650 3584 
-Q 3113 3584 3367 3334 
-Q 3622 3084 3622 2631 
-Q 3622 2519 3608 2391 
-Q 3594 2263 3566 2113 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-4e" d="M 1172 4863 
-L 1747 4863 
-L 1197 2028 
-L 3169 3500 
-L 3916 3500 
-L 1716 1825 
-L 3322 0 
-L 2625 0 
-L 1131 1709 
-L 800 0 
-L 225 0 
-L 1172 4863 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-1e" d="M 563 794 
-L 1222 794 
-L 1113 256 
-L 409 -744 
-L 6 -744 
-L 453 256 
-L 563 794 
-z
-M 1050 3309 
-L 1709 3309 
-L 1556 2516 
-L 897 2516 
-L 1050 3309 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-33" d="M 1081 4666 
-L 2541 4666 
-Q 3178 4666 3512 4369 
-Q 3847 4072 3847 3500 
-Q 3847 2731 3353 2303 
-Q 2859 1875 1966 1875 
-L 1172 1875 
-L 806 0 
-L 172 0 
-L 1081 4666 
-z
-M 1613 4147 
-L 1275 2394 
-L 2069 2394 
-Q 2606 2394 2893 2669 
-Q 3181 2944 3181 3456 
-Q 3181 3784 2986 3965 
-Q 2791 4147 2438 4147 
-L 1613 4147 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-4a" d="M 3816 3500 
-L 3219 434 
-Q 3047 -456 2561 -893 
-Q 2075 -1331 1253 -1331 
-Q 950 -1331 690 -1286 
-Q 431 -1241 206 -1147 
-L 313 -588 
-Q 525 -725 762 -790 
-Q 1000 -856 1269 -856 
-Q 1816 -856 2167 -557 
-Q 2519 -259 2631 300 
-L 2681 563 
-Q 2441 288 2122 144 
-Q 1803 0 1434 0 
-Q 903 0 598 351 
-Q 294 703 294 1319 
-Q 294 1803 478 2267 
-Q 663 2731 997 3091 
-Q 1219 3328 1514 3456 
-Q 1809 3584 2131 3584 
-Q 2484 3584 2746 3420 
-Q 3009 3256 3138 2956 
-L 3238 3500 
-L 3816 3500 
-z
-M 2950 2216 
-Q 2950 2641 2750 2872 
-Q 2550 3103 2181 3103 
-Q 1953 3103 1747 3012 
-Q 1541 2922 1394 2759 
-Q 1156 2491 1023 2127 
-Q 891 1763 891 1375 
-Q 891 944 1092 712 
-Q 1294 481 1672 481 
-Q 2219 481 2584 976 
-Q 2950 1472 2950 2216 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-b" d="M 2731 4856 
-Q 1903 3822 1495 2892 
-Q 1088 1963 1088 1100 
-Q 1088 606 1206 120 
-Q 1325 -366 1563 -844 
-L 1063 -844 
-Q 775 -306 634 201 
-Q 494 709 494 1197 
-Q 494 2125 923 3036 
-Q 1353 3947 2222 4856 
-L 2731 4856 
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-49" d="M 3059 4863 
-L 2969 4384 
-L 2419 4384 
-Q 2106 4384 1964 4261 
-Q 1822 4138 1753 3809 
-L 1691 3500 
-L 2638 3500 
-L 2553 3053 
-L 1606 3053 
-L 1013 0 
-L 434 0 
-L 1031 3053 
-L 481 3053 
-L 563 3500 
-L 1113 3500 
-L 1159 3744 
-Q 1278 4363 1576 4613 
-Q 1875 4863 2516 4863 
-L 3059 4863 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-50" d="M 5747 2113 
@@ -2710,17 +2861,25 @@ L 616 4666
 L 1147 4666 
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Oblique-c" d="M -397 -844 
-Q 434 191 840 1120 
-Q 1247 2050 1247 2913 
-Q 1247 3406 1130 3892 
-Q 1013 4378 775 4856 
-L 1275 4856 
-Q 1563 4316 1703 3812 
-Q 1844 3309 1844 2822 
-Q 1844 1891 1411 973 
-Q 978 56 116 -844 
-L -397 -844 
+     <path id="DejaVuSans-Oblique-4d" d="M 928 3500 
+L 1503 3500 
+L 813 -63 
+L 809 -78 
+Q 694 -675 544 -897 
+Q 403 -1106 132 -1218 
+Q -138 -1331 -506 -1331 
+L -722 -1331 
+L -628 -844 
+L -481 -844 
+Q -144 -844 -1 -703 
+Q 141 -563 238 -63 
+L 928 3500 
+z
+M 1197 4863 
+L 1772 4863 
+L 1631 4134 
+L 1056 4134 
+L 1197 4863 
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Oblique-11" d="M 525 794 
@@ -2731,149 +2890,102 @@ L 525 794
 z
 " transform="scale(0.015625)"/>
     </defs>
-    <use xlink:href="#DejaVuSans-Oblique-28"/>
-    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(63.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(124.46875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(179.453125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(242.828125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(274.609375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(326.703125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(388.234375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(429.34375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(457.125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(518.65625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(570.75 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(602.53125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(666.015625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(707.125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(768.40625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(850.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(902.28125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(934.0625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(986.15625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(1047.6875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1111.171875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1172.453125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1213.5625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(1274.84375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1314.046875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(1375.578125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(1403.359375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-f" transform="translate(1454.78125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1486.5625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1518.34375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1570.4375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1631.625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(1663.40625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(1732.015625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-35" transform="translate(1800.421875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(1869.90625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(1919.90625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-37" transform="translate(1983.390625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(2035.296875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-26" transform="translate(2103.703125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-2e" transform="translate(2173.53125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(2239.109375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-27" transform="translate(2302.296875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2379.296875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2411.078125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2452.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(2513.71875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(2577.09375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2640.578125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2702.109375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2743.21875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2795.3125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(2827.09375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(2854.875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4e" transform="translate(2882.65625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2940.5625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3002.09375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-25" transform="translate(3033.875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-24" transform="translate(3102.484375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-35" transform="translate(3170.890625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(3240.375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3274.0625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-36" transform="translate(3305.84375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-37" transform="translate(3369.328125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-28" transform="translate(3430.40625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-33" transform="translate(3493.59375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3553.890625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3585.671875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3637.765625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3701.140625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(3762.328125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3844.109375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3896.203125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(3927.984375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(3967.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4030.5625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4092.09375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4123.875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(4185.40625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4a" transform="translate(4248.890625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4312.375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4373.90625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4405.6875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(4466.875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4530.25 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(4558.03125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(4617.21875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-b" transform="translate(4649 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(4688.015625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(4729.125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-46" transform="translate(4790.65625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4845.640625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(4906.828125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(4934.609375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(4995.796875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5036.90625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(5098.4375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5161.921875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5193.703125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5257.078125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(5318.609375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5359.71875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5421.25 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-49" transform="translate(5453.03125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(5488.234375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(5529.34375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(5590.53125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5687.9375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(5719.71875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5758.921875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(5822.296875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(5883.828125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(5915.609375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(5954.8125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(6018.1875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(6079.71875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(6177.125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-a" transform="translate(6238.65625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(6266.140625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(6318.234375 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(6350.015625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(6431.796875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(6495.171875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(6522.953125 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(6562.15625 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-c" transform="translate(6623.6875 0)"/>
-    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(6662.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-37"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(61.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(124.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(185.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(217.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5c" transform="translate(256.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-53" transform="translate(316.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(379.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(441.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(472.953125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(514.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(575.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(638.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(702.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(763.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(805.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(857.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(888.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-51" transform="translate(950.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1013.53125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1075.0625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1106.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1158.9375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1220.46875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(1261.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1289.359375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1350.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-1e" transform="translate(1402.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1436.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(1468.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(1531.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5a" transform="translate(1593.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(1674.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(1706.578125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1758.671875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-59" transform="translate(1820.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(1879.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(1940.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(1982.03125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4f" transform="translate(2043.3125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2071.09375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2102.875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2154.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2216.5 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(2257.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2285.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2346.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2399.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(2430.796875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(2482.890625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2546.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(2607.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2648.65625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2710.1875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-57" transform="translate(2741.96875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4b" transform="translate(2781.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(2844.546875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(2906.078125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(2937.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-5b" transform="translate(2999.140625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(3058.328125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3086.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3138.203125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4c" transform="translate(3169.984375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3197.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3249.859375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-45" transform="translate(3281.640625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-44" transform="translate(3345.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-55" transform="translate(3406.40625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-42" transform="translate(3447.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-50" transform="translate(3497.515625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3594.921875 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-47" transform="translate(3656.109375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-48" transform="translate(3719.59375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-a" transform="translate(3781.125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-56" transform="translate(3808.609375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-3" transform="translate(3860.703125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-4d" transform="translate(3892.484375 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-52" transform="translate(3920.265625 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-45" transform="translate(3981.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Oblique-11" transform="translate(4044.9375 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="pc63cb2a5b7">
-   <rect x="58.113326" y="20.037891" width="230.60202" height="104.102254"/>
+  <clipPath id="p8ebb63f4e7">
+   <rect x="22.5975" y="20.037891" width="230.60202" height="104.101903"/>
   </clipPath>
-  <clipPath id="p31ecac502f">
-   <rect x="310.113326" y="20.037891" width="230.60202" height="104.102254"/>
+  <clipPath id="p78e3c19c9c">
+   <rect x="274.5975" y="20.037891" width="230.60202" height="104.101903"/>
   </clipPath>
-  <clipPath id="pe788ef890e">
-   <rect x="58.113326" y="156.837891" width="230.60202" height="104.102254"/>
+  <clipPath id="p40f877edb4">
+   <rect x="22.5975" y="156.838242" width="230.60202" height="104.101903"/>
   </clipPath>
-  <clipPath id="pee49dd4bbf">
-   <rect x="310.113326" y="156.837891" width="230.60202" height="104.102254"/>
+  <clipPath id="pac85666f41">
+   <rect x="274.5975" y="156.838242" width="230.60202" height="104.101903"/>
   </clipPath>
  </defs>
 </svg>

--- a/docs/assets/scripts/generate_constant_viz.py
+++ b/docs/assets/scripts/generate_constant_viz.py
@@ -495,34 +495,37 @@ def bar_mode():
 def histogram_type():
     members = [
         ("BAR", HISTOGRAM_TYPE.BAR),
-        ("BAR_STACKED", HISTOGRAM_TYPE.BAR_STACKED),
         ("STEP", HISTOGRAM_TYPE.STEP),
         ("STEP_FILLED", HISTOGRAM_TYPE.STEP_FILLED),
     ]
-    values = np.random.default_rng(42).normal(0, 1, 400)
+    rng = np.random.default_rng(42)
+    values = rng.normal(0, 1, 400)
     figs = [
         Histogram(
             data=[{"x": x} for x in values],
-            # STEP draws only the edge, which the DEFAULT theme paints white
-            style={
-                "plot_hist_type": value,
-                **(
-                    {"plot_hist_edge_color": DARK, "plot_hist_edge_width": 1.2}
-                    if value == HISTOGRAM_TYPE.STEP
-                    else {}
-                ),
-            },
+            style={"plot_hist_type": value},
             title=f"HISTOGRAM_TYPE.{label}",
         )
         for label, value in members
     ]
+    # the fourth panel shows the orthogonal axis: series sharing via bar_mode
+    figs.append(
+        Histogram(
+            data=[
+                [{"x": x} for x in values],
+                [{"x": x} for x in rng.normal(2.5, 0.8, 250)],
+            ],
+            bar_mode="stack",
+            title='bar_mode="stack"',
+        )
+    )
     chart_grid(
         figs,
         "const-histogram-type.svg",
         3.8,
         cols=2,
-        footnote="Each series draws separately, so BAR_STACKED renders like BAR; "
-        "STEP shows the edge only (recolored here from the theme's white).",
+        footnote="The type renders one series; how several series share the "
+        "axis is bar_mode's job.",
     )
 
 

--- a/docs/how-to-guides/charts/histogram.ipynb
+++ b/docs/how-to-guides/charts/histogram.ipynb
@@ -317,6 +317,7 @@
     "| highlight one series, mute the rest     | `emphasis`                                                              | [Emphasis](#emphasis) |\n",
     "| mark a threshold or a reference value   | `vlines`, `hlines`                                                      | [Reference lines](#reference-lines) |\n",
     "| compare several series in one chart     | `data` as a list of lists, `subtitle`, `show_legend`                    | [Multiple Histograms](#multiple-histograms) |\n",
+    "| stack or overlay the series             | `bar_mode`                                                              | [Multiple Histograms](#multiple-histograms) |\n",
     "| draw each series in its own subplot     | `subplots`, `sharex`, `sharey`, `max_cols`                              | [Subplots](#subplots) |\n",
     "| show densities or cumulative counts     | `show_density`, `show_cumulative`                                       | [Histogram Views](#histogram-views) |\n",
     "| use a logarithmic axis                  | `scalex`, `scaley`                                                      | [Axis scales](#axis-scales) |\n",
@@ -539,11 +540,10 @@
     "| Type            | Description |\n",
     "| :-------------- | :---------- |\n",
     "| `\"bar\"`         | One bar per bin (the default). |\n",
-    "| `\"barstacked\"`  | One bar per bin, with several series stacked on top of each other. |\n",
     "| `\"step\"`        | An unfilled outline that steps from bin to bin. |\n",
     "| `\"stepfilled\"`  | A filled outline that steps from bin to bin. |\n",
     "\n",
-    "The step types draw their outline in the `plot_hist_edge_color`, which the default theme sets to white to separate the bars — set it explicitly when switching to a step type, or the outline disappears into the background.\n",
+    "The type is a per-series render style; how several series share the axis is the `bar_mode` argument's job (see [Multiple Histograms](#multiple-histograms)). For `\"step\"` the outline is the mark itself, so it draws in the series color at the theme's line width; `plot_hist_edge_color` and `plot_hist_edge_width` override that explicitly.\n",
     "\n",
     "The example below changes the color, transparency, hatch, outline and type of the histogram in one go. Any attribute you leave out keeps the value of the active theme."
    ]
@@ -851,7 +851,7 @@
     "    </p>\n",
     "</div>\n",
     "\n",
-    "The `penguins_by_species` dataset is such a list of lists, one series per species. By default, multiple histograms in one chart are binned on shared bins and **stacked** on top of each other, so the outline of the stack is the histogram of all the values together and each color shows a species' share of every bin. Separate series can also be styled separately: a single `style` dictionary applies to every chart, while a list of dictionaries styles each chart on its own (`None` keeps the theme style for that chart)."
+    "The `penguins_by_species` dataset is such a list of lists, one series per species. By default, multiple histograms in one chart are binned on shared bins and **stacked** on top of each other, so the outline of the stack is the histogram of all the values together and each color shows a species' share of every bin. Pass `bar_mode=\"overlay\"` to draw the series individually over each other instead. Separate series can also be styled separately: a single `style` dictionary applies to every chart, while a list of dictionaries styles each chart on its own (`None` keeps the theme style for that chart)."
    ]
   },
   {

--- a/test/test_histogram.py
+++ b/test/test_histogram.py
@@ -1,0 +1,161 @@
+"""Tests for histogram bar_mode stacking and STEP edge defaults."""
+
+import unittest
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+from datachart.charts import Histogram
+from datachart.config import config
+from datachart.utils import Panel
+from datachart.utils._internal.layers import build_chart_panel_settings
+
+# deterministic series: combined range 0.5-2.5, num_bins=3 puts the values
+# 0.5 / 1.5 / 2.5 into bins 0 / 1 / 2 with counts A=[4,2,0], B=[1,0,3]
+HIST_A = [{"x": v} for v in [0.5] * 4 + [1.5] * 2]
+HIST_B = [{"x": v} for v in [0.5] * 1 + [2.5] * 3]
+
+
+def container_bottoms(figure, index):
+    return [p.get_y() for p in figure.axes[0].containers[index].patches]
+
+
+class TestHistogramBarMode(unittest.TestCase):
+    def setUp(self):
+        config.reset_config()
+
+    def tearDown(self):
+        config.reset_config()
+        plt.close("all")
+
+    def test_panel_settings_default_stack_for_histograms(self):
+        settings = build_chart_panel_settings("histogram", {}, "single", {})
+        self.assertEqual(settings["bar_mode"], "stack")
+
+    def test_panel_settings_default_group_for_bars(self):
+        settings = build_chart_panel_settings("barchart", {}, "single", {})
+        self.assertEqual(settings["bar_mode"], "group")
+
+    def test_panel_settings_explicit_bar_mode_passes_through(self):
+        settings = build_chart_panel_settings(
+            "histogram", {"bar_mode": "overlay"}, "single", {}
+        )
+        self.assertEqual(settings["bar_mode"], "overlay")
+
+    def test_default_stacks_multiple_series(self):
+        figure = Histogram([HIST_A, HIST_B], num_bins=3)
+        self.assertEqual(container_bottoms(figure, 0), [0, 0, 0])
+        self.assertEqual(container_bottoms(figure, 1), [4, 2, 0])
+
+    def test_overlay_draws_each_series_from_zero(self):
+        figure = Histogram([HIST_A, HIST_B], num_bins=3, bar_mode="overlay")
+        self.assertEqual(container_bottoms(figure, 0), [0, 0, 0])
+        self.assertEqual(container_bottoms(figure, 1), [0, 0, 0])
+
+    def test_group_behaves_as_overlay_for_histograms(self):
+        figure = Histogram([HIST_A, HIST_B], num_bins=3, bar_mode="group")
+        self.assertEqual(container_bottoms(figure, 1), [0, 0, 0])
+
+    def test_stacked_density_normalizes_the_whole_stack(self):
+        figure = Histogram([HIST_A, HIST_B], num_bins=3, show_density=True)
+        area = sum(
+            p.get_height() * p.get_width()
+            for c in figure.axes[0].containers
+            for p in c.patches
+        )
+        self.assertAlmostEqual(area, 1.0)
+
+    def test_stacked_cumulative_accumulates_per_series_counts(self):
+        figure = Histogram([HIST_A, HIST_B], num_bins=3, show_cumulative=True)
+        heights_a = [p.get_height() for p in figure.axes[0].containers[0].patches]
+        bottoms_b = container_bottoms(figure, 1)
+        self.assertEqual(heights_a, [4, 6, 6])
+        self.assertEqual(bottoms_b, [4, 6, 6])
+
+    def test_single_series_needs_no_stack(self):
+        figure = Histogram(HIST_A, num_bins=3)
+        heights = [p.get_height() for p in figure.axes[0].containers[0].patches]
+        self.assertEqual(sum(heights), 6)
+
+    def test_panel_composition_stacks_histograms(self):
+        f1 = Histogram(HIST_A, num_bins=3, subtitle="a")
+        f2 = Histogram(HIST_B, num_bins=3, subtitle="b")
+        panel = Panel([{"figure": f1}, {"figure": f2}], bar_mode="stack")
+        bottoms = [p.get_y() for p in panel.axes[0].containers[1].patches]
+        self.assertEqual(bottoms, [4, 2, 0])
+
+    def test_panel_composition_default_overlays(self):
+        f1 = Histogram(HIST_A, num_bins=3, subtitle="a")
+        f2 = Histogram(HIST_B, num_bins=3, subtitle="b")
+        panel = Panel([{"figure": f1}, {"figure": f2}])
+        bottoms = [p.get_y() for p in panel.axes[0].containers[1].patches]
+        self.assertEqual(bottoms, [0, 0, 0])
+
+
+class TestStepEdgeDefaults(unittest.TestCase):
+    def setUp(self):
+        config.reset_config()
+
+    def tearDown(self):
+        config.reset_config()
+        plt.close("all")
+
+    def test_step_edge_follows_series_color(self):
+        figure = Histogram(HIST_A, num_bins=3, style={"plot_hist_type": "step"})
+        patch = figure.axes[0].patches[0]
+        edge = matplotlib.colors.to_hex(patch.get_edgecolor())
+        self.assertNotEqual(edge.lower(), "#ffffff")
+        # the outline is the series mark: it carries the series color
+        face = matplotlib.colors.to_hex(patch.get_facecolor())
+        self.assertEqual(edge, face)
+
+    def test_step_edge_width_defaults_to_line_width(self):
+        figure = Histogram(HIST_A, num_bins=3, style={"plot_hist_type": "step"})
+        patch = figure.axes[0].patches[0]
+        self.assertEqual(patch.get_linewidth(), config["plot_line_width"])
+
+    def test_explicit_edge_style_wins_over_step_defaults(self):
+        figure = Histogram(
+            HIST_A,
+            num_bins=3,
+            style={
+                "plot_hist_type": "step",
+                "plot_hist_edge_color": "#000000",
+                "plot_hist_edge_width": 3.0,
+            },
+        )
+        patch = figure.axes[0].patches[0]
+        self.assertEqual(matplotlib.colors.to_hex(patch.get_edgecolor()), "#000000")
+        self.assertEqual(patch.get_linewidth(), 3.0)
+
+    def test_filled_types_keep_theme_edges(self):
+        figure = Histogram(HIST_A, num_bins=3)
+        patch = figure.axes[0].containers[0].patches[0]
+        self.assertEqual(
+            matplotlib.colors.to_hex(patch.get_edgecolor()),
+            config["plot_hist_edge_color"].lower(),
+        )
+        self.assertEqual(patch.get_linewidth(), config["plot_hist_edge_width"])
+
+    def test_multi_series_step_stacks_as_filled(self):
+        figure = Histogram(
+            [HIST_A, HIST_B], num_bins=3, style={"plot_hist_type": "step"}
+        )
+        patches = figure.axes[0].patches
+        self.assertTrue(all(p.get_fill() for p in patches))
+
+    def test_multi_series_step_overlay_keeps_outlines(self):
+        figure = Histogram(
+            [HIST_A, HIST_B],
+            num_bins=3,
+            bar_mode="overlay",
+            style={"plot_hist_type": "step"},
+        )
+        patches = figure.axes[0].patches
+        self.assertTrue(all(not p.get_fill() for p in patches))
+        edges = {matplotlib.colors.to_hex(p.get_edgecolor()) for p in patches}
+        self.assertEqual(len(edges), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Two `HISTOGRAM_TYPE` members didn't do what they said: `BAR_STACKED` never stacked (each series draws through its own `ax.hist` call, so it rendered identically to `BAR`), and `STEP` was invisible under fill-oriented theme edges (white in DEFAULT, width 0 in MATERIAL/MINIMAL). `HISTOGRAM_TYPE` is now strictly a per-series render style, how series share the axis moves to `bar_mode` (now accepted by the Histogram front), and STEP's outline defaults to the series color at the theme's line width. Design recorded in ADR 0014.

## Changes
- Removed `HISTOGRAM_TYPE.BAR_STACKED` (no deprecation alias, pre-1.0 policy).
- `Histogram` accepts `bar_mode`: `"stack"` (default, preserves prior behavior) stacks series on shared bins; `"overlay"` draws them individually; `"group"` has no histogram meaning and behaves as `"overlay"` (documented, no warning).
- `Panel` now precomputes per-layer stack heights/bottoms on panel-shared bin edges (matching matplotlib's stacked math, density and cumulative included) and hands them to each layer via a `HistSlot` on the frozen `DrawContext` — parallel to `BarSlot`; this replaces the single-call `_draw_hist_stack` and the internal `hist_mode` setting, so composed `Panel`s can now stack histograms via `bar_mode="stack"` too.
- Multi-series STEP under `bar_mode="stack"` draws as its filled equivalent (`stepfilled`), since a stack needs area; single-series and overlaid STEP keep the outline.
- STEP edge defaults: color follows the series cycle color, width follows the theme's `plot_line_width`; explicit `plot_hist_edge_*` chart styles override, filled types keep theme edges. Themes untouched.
- Docs: `HISTOGRAM_TYPE`/`BAR_MODE` docstrings, histogram guide notebook, `_HistogramChartAttrs` typings; `const-histogram-type.svg` regenerated without the STEP recolor workaround, with a `bar_mode="stack"` panel (only that image changed).
- New `test/test_histogram.py` covering bar_mode resolution, stacking math (incl. density/cumulative), composition stacking, and STEP edge defaults.

Decisions made where the plan left them open: histogram default `bar_mode="stack"` (preserves existing default rendering); `"group"` → overlay fallback without warning (composition panels default to `"group"`, a warning would fire constantly); step-in-stack → filled equivalent (verified pixel-equivalent stacking for bar/stepfilled; unfilled step cannot reproduce matplotlib's stacked outlines via per-layer bottoms).

## Test plan
- `python -m pytest test/ --ignore=test/golden` → 231 passed (includes 17 new histogram tests)
- `python -m unittest discover test` → 105 passed
- Golden harness: baseline rendered from `main` (9d94e4d) sources, candidate from this branch → 56/56 cases pixel-identical (stacking refactor is behavior-preserving; no STEP cases existed in the suite)
- `pytest --nbmake docs/how-to-guides/charts/histogram.ipynb` → 1 passed
- `python -m black datachart` → unchanged
