### PR TITLE
ci: split notebook tests from the python matrix

### DIFF
--- a/.github/workflows/unittests.yaml
+++ b/.github/workflows/unittests.yaml
@@ -3,29 +3,39 @@ name: Test
 on:
   push:
     branches: [main]
+    paths-ignore: ["**.md", "mkdocs.yml", "docs/adr/**", "docs/agents/**"]
   pull_request:
     branches: [main]
+    paths-ignore: ["**.md", "mkdocs.yml", "docs/adr/**", "docs/agents/**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
+  unit:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install package
-        run: |
-          python -m pip install --upgrade pip
-          pip install -e .[test]
-      - name: Test with unittest
-        run: |
-          python -m unittest discover test
+          cache: pip
+      - run: pip install -e .[test]
+      - run: python -m unittest discover test
 
-      - name: Test notebook docs
-        run: |
-          pytest --nbmake ./docs/how-to-guides/**/*ipynb
+  notebooks:
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: pip install -e .[test]
+      - run: pytest --nbmake ./docs/how-to-guides/**/*ipynb


### PR DESCRIPTION
## Summary

The test workflow ran both the unit tests and the slow notebook suite on every Python version for every push and PR. Notebook tests validate the docs, not interpreter compatibility, so they now run once, after the unit matrix passes.

## Changes

- Split `unit` (Python 3.10–3.13 matrix, `fail-fast: false`) from `notebooks` (3.12 only, `needs: unit`)
- Add a `concurrency` group with `cancel-in-progress` so superseded runs on the same ref are cancelled
- Enable pip caching in `setup-python`
- Skip CI for docs-only changes (`**.md`, `mkdocs.yml`, `docs/adr/**`, `docs/agents/**`)

## Test plan

Not run locally — CI-only change; the workflow run on this PR is the verification.
