### PR TITLE
ci(docs): version the site with mike

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,17 +1,26 @@
 name: Documentation
 
+# main -> `dev`; published releases -> `X.Y.Z` + `latest` (the site default)
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
 
 permissions:
   contents: write
+
+concurrency:
+  group: docs
+  cancel-in-progress: false
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
       - uses: actions/setup-python@v5
         with:
@@ -24,4 +33,12 @@ jobs:
           restore-keys: |
             mkdocs-material-
       - run: uv sync --group docs
-      - run: uv run mkdocs gh-deploy --force
+      - run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - if: github.event_name == 'push'
+        run: uv run mike deploy --push dev
+      - if: github.event_name == 'release'
+        run: |
+          uv run mike deploy --push --update-aliases "${GITHUB_REF_NAME#v}" latest
+          uv run mike set-default --push latest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,11 @@ theme:
 
 edit_uri: ""
 
+extra:
+  version:
+    provider: mike
+    default: latest
+
 extra_css:
   - css/extra.css
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ Changelog = "https://github.com/eriknovak/datachart/blob/main/CHANGELOG.md"
 [dependency-groups]
 test = ["coverage", "nbmake", "pytest"]
 docs = [
+    "mike",
     "mkdocs-material",
     "mkdocs-jupyter",
     # <1.2.3: 1.2.3 pulls in the properdocs fork of mkdocs and a build-time banner

--- a/uv.lock
+++ b/uv.lock
@@ -764,6 +764,7 @@ dependencies = [
 dev = [
     { name = "black" },
     { name = "coverage" },
+    { name = "mike" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
@@ -774,6 +775,7 @@ dev = [
     { name = "python-githooks" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-llmstxt" },
     { name = "mkdocs-material" },
@@ -798,6 +800,7 @@ requires-dist = [
 dev = [
     { name = "black" },
     { name = "coverage" },
+    { name = "mike" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-llmstxt", specifier = "==0.5.0" },
     { name = "mkdocs-material" },
@@ -808,6 +811,7 @@ dev = [
     { name = "python-githooks" },
 ]
 docs = [
+    { name = "mike" },
     { name = "mkdocs-jupyter" },
     { name = "mkdocs-llmstxt", specifier = "==0.5.0" },
     { name = "mkdocs-material" },
@@ -1643,6 +1647,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mike"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "verspec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b4/47/fa87e9d56bef16cdfe34b059a437e8c6f7ec6f1b9c378871c3cf95ebea9c/mike-2.2.0.tar.gz", hash = "sha256:1e3858e32c0f125aac14432fc7848434358f9ae0962c5c5cde387ad47f6ad25e", size = 38450, upload-time = "2026-04-14T04:59:03.944Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/8e/56ccb09c7232a55403a7637caa21922f3b65901a37f5e8bdb405d0de0946/mike-2.2.0-py3-none-any.whl", hash = "sha256:e1f4981c1152eec7c2490a3401142292cc47d686194188416db2648fdfe1d040", size = 34026, upload-time = "2026-04-14T04:59:02.602Z" },
 ]
 
 [[package]]
@@ -3248,6 +3269,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "verspec"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/44/8126f9f0c44319b2efc65feaad589cadef4d77ece200ae3c9133d58464d0/verspec-0.1.0.tar.gz", hash = "sha256:c4504ca697b2056cdb4bfa7121461f5a0e81809255b41c03dda4ba823637c01e", size = 27123, upload-time = "2020-11-30T02:24:09.646Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl", hash = "sha256:741877d5633cc9464c45a469ae2a31e801e6dbbaa85b9675d481cda100f11c31", size = 19640, upload-time = "2020-11-30T02:24:08.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The docs site currently tracks `main`, so it never reflects what a released package actually provides. This versions the site with `mike`: published releases get their own frozen snapshot plus a `latest` alias (the site default), while `main` keeps deploying as `dev`. Stacked on #73 (needs the `docs` dependency group).

## Changes

- `documentation.yaml`: also triggers on `release: published`; `main` push → `mike deploy dev`, release → `mike deploy X.Y.Z latest` + `set-default latest`
- `mkdocs.yml`: `extra.version.provider: mike` enables the mkdocs-material version selector
- `pyproject.toml` / `uv.lock`: add `mike` to the `docs` group

## Test plan

- `uv run mkdocs build` passes locally with the version selector rendered
- Not tested end to end — first `mike deploy` rewrites `gh-pages` to the versioned layout; until the next release, run once locally: `uv run mike deploy --push --update-aliases 0.8.1 latest && uv run mike set-default --push latest`
