### PR TITLE
fix(grid): keep a host row's height when a nested grid sits alone in it

### DIFF
--- a/datachart/utils/_internal/figures.py
+++ b/datachart/utils/_internal/figures.py
@@ -9,8 +9,10 @@ pyplot's global figure manager. Displaying is explicit via
 import io
 import warnings
 
+import matplotlib._constrained_layout as _constrained_layout
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
+from matplotlib.layout_engine import ConstrainedLayoutEngine
 
 
 def _in_notebook_kernel() -> bool:
@@ -71,6 +73,60 @@ class DatachartFigure(Figure):
             plt.show()
 
 
+def _propagate_nested_margins(layoutgrids) -> None:
+    """Lift each nested gridspec's outer margins onto its parent cell.
+
+    Constrained layout equalises the *inner* height of a gridspec's rows, and
+    a row whose only content is a nested gridspec has no margins of its own,
+    so it shrinks by its siblings' margins — a nested Grid alone in a host
+    row collapses. Deepest nesting first, so margins reach the outermost grid.
+    """
+    nested = [gs for gs in layoutgrids if hasattr(gs, "_subplot_spec")]
+
+    def depth(gs):
+        d = 0
+        while hasattr(gs, "_subplot_spec"):
+            gs = gs._subplot_spec.get_gridspec()
+            d += 1
+        return d
+
+    for gs in sorted(nested, key=depth, reverse=True):
+        lg = layoutgrids[gs]
+        vals = lg.margin_vals
+        subplot_spec = gs._subplot_spec
+        parent = layoutgrids.get(subplot_spec.get_gridspec())
+        if parent is None:
+            continue
+        margin = {
+            "left": vals["left"][0],
+            "leftcb": vals["leftcb"][0],
+            "right": vals["right"][-1],
+            "rightcb": vals["rightcb"][-1],
+            "top": vals["top"][0],
+            "topcb": vals["topcb"][0],
+            "bottom": vals["bottom"][-1],
+            "bottomcb": vals["bottomcb"][-1],
+        }
+        parent.edit_outer_margin_mins(margin, subplot_spec)
+
+
+class NestedGridLayoutEngine(ConstrainedLayoutEngine):
+    """Constrained layout whose nested gridspecs size their parent cell."""
+
+    def execute(self, fig):
+        original = _constrained_layout.make_layout_margins
+
+        def make_layout_margins(layoutgrids, *args, **kwargs):
+            original(layoutgrids, *args, **kwargs)
+            _propagate_nested_margins(layoutgrids)
+
+        _constrained_layout.make_layout_margins = make_layout_margins
+        try:
+            return super().execute(fig)
+        finally:
+            _constrained_layout.make_layout_margins = original
+
+
 def new_figure(figsize=None) -> DatachartFigure:
     """Create an unmanaged, constrained-layout figure.
 
@@ -84,6 +140,6 @@ def new_figure(figsize=None) -> DatachartFigure:
         The unmanaged figure.
 
     """
-    figure = DatachartFigure(figsize=figsize, layout="constrained")
+    figure = DatachartFigure(figsize=figsize, layout=NestedGridLayoutEngine())
     FigureCanvasAgg(figure)
     return figure

--- a/docs/adr/0007-nested-grid-alignment.md
+++ b/docs/adr/0007-nested-grid-alignment.md
@@ -27,5 +27,12 @@ those already align — so one layout pass aligns every cell.
 - **One rendering mechanism for nested cells.** Nested grids and multi-subplot
   figures both rebuild via subgridspec in the owner figure; the subfigure path
   is deleted. The transport (recursive cell tree) is unchanged.
+- **A nested cell sizes its parent cell.** Constrained layout equalises the
+  inner height of a gridspec's rows, and a row holding only a nested
+  gridspec has no margins of its own, so it shrinks by its siblings' margins
+  — a nested grid alone in a host row collapsed (#86). The figure's layout
+  engine lifts every nested gridspec's outer margins onto its parent cell,
+  deepest first, so such a row keeps its siblings' height. This covers
+  multi-subplot cells too, which rebuild through the same subgridspec.
 - **Golden churn is the fix.** Nested-grid golden images change and are
   re-baselined deliberately; all non-nested cases stay pixel-identical.

--- a/test/golden/golden.py
+++ b/test/golden/golden.py
@@ -128,6 +128,8 @@ EXPECTED_CHANGES = {
     "hexbin_subplots",
     "hexbin_panel_scatter",
     "hexbin_grid",
+    # nested gridspecs size their parent cell (ADR 0007, issue #86)
+    "grid_nested_grid",
 }
 
 

--- a/test/test_compose.py
+++ b/test/test_compose.py
@@ -384,6 +384,18 @@ class TestNestedGrid:
             assert ax.get_position().y1 < sibling.get_position().y1
         plt.close("all")
 
+    def test_nested_grid_alone_in_row_keeps_row_height(self):
+        inner = Grid([_line_fig(), _line_fig()])
+        fig = Grid([_bar_fig(), _bar_fig(), _bar_fig(), inner], max_cols=3)
+        fig.canvas.draw()
+        sibling = next(ax for ax in fig.axes if ax not in _nested_axes(fig))
+        nested = [ax for ax in _nested_axes(fig) if ax.axison]
+        envelope = max(ax.get_position().y1 for ax in nested) - min(
+            ax.get_position().y0 for ax in nested
+        )
+        assert envelope == pytest.approx(sibling.get_position().height, abs=1e-2)
+        plt.close("all")
+
     def test_nested_grid_keeps_own_furniture(self):
         inner = Grid([_line_fig(), _line_fig()], title="Inner", sharey=True)
         outer = Grid([inner, _bar_fig()], title="Outer")


### PR DESCRIPTION
## Summary
A nested `Grid` (or multi-subplot figure) that was the only cell in a host `Grid` row rendered squashed. Constrained layout equalises the *inner* height of a gridspec's rows, and a row holding only a nested subgridspec has no margins of its own, so it shrank by its siblings' margin size. The figure's layout engine now lifts each nested gridspec's outer margins onto its parent cell, so such a row keeps its siblings' height.

## Changes
- `datachart/utils/_internal/figures.py`: `NestedGridLayoutEngine` (a `ConstrainedLayoutEngine` subclass) propagates every nested gridspec's outer margins onto its parent cell, deepest first; `new_figure` uses it.
- `test/test_compose.py`: regression test — a nested grid alone in the last row keeps its siblings' axes envelope height (fails on `main`).
- `test/golden/golden.py`: `grid_nested_grid` added to `EXPECTED_CHANGES`.
- `docs/adr/0007-nested-grid-alignment.md`: records the "nested cell sizes its parent cell" commitment.

## Test plan
- `python -m unittest discover test` → 275 OK
- `pytest` (notebooks) → 23 passed
- `python test/golden/golden.py candidate` → 97 identical; only `grid_nested_grid`, `grid_subplot_figure`, `grid_mixed_panel_and_grid` differ (nested/multi-subplot cells gain their margin room; all other cases pixel-identical)
- Issue repro rendered: nested envelope height 0.471 vs sibling 0.471 (was 0.461); with 31 figures at `max_cols=3` the alone-in-row nested grid no longer collapses.

Closes #86
