### PR TITLE
docs: remove the stray "Under development" notes from the config and stats guides

### DIFF
--- a/docs/how-to-guides/styling/config.ipynb
+++ b/docs/how-to-guides/styling/config.ipynb
@@ -45,18 +45,6 @@
     "\n",
     "Furthemore, the instance is of the [datachart.config.Config](../../../references/config/#datachart.config.Config) class."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"admonition note\">\n",
-    "    <p class=\"admonition-title\">Under development</p>\n",
-    "    <p style=\"margin-top: .6rem; margin-bottom: .6rem\">\n",
-    "        This theme is still under development. If you are interested in improving it, please let us know.\n",
-    "    </p>\n",
-    "</div>"
-   ]
   }
  ],
  "metadata": {

--- a/docs/how-to-guides/utility/stats.ipynb
+++ b/docs/how-to-guides/utility/stats.ipynb
@@ -841,18 +841,6 @@
     "surface = kde2d(random_values, random_values_2, gridsize=3)\n",
     "surface"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<div class=\"admonition note\">\n",
-    "    <p class=\"admonition-title\">Under development</p>\n",
-    "    <p style=\"margin-top: .6rem; margin-bottom: .6rem\">\n",
-    "        This theme is still under development. If you are interested in improving it, please let us know.\n",
-    "    </p>\n",
-    "</div>"
-   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
The Statistics and Config guides ended with an "Under development" admonition copied from the theme pages ("This theme is still under development…"). Neither page is a theme nor under development, so the notes are removed. A sweep of `docs/` found no other copies.

## Changes
- Delete the trailing "Under development" markdown cell from `docs/how-to-guides/utility/stats.ipynb`
- Delete the same cell from `docs/how-to-guides/styling/config.ipynb`

## Test plan
- `pytest docs/how-to-guides/styling/config.ipynb docs/how-to-guides/utility/stats.ipynb` → 2 passed
- `grep -ri "under development" docs` → no matches

Closes #90
